### PR TITLE
Delete in progress surveys on restart

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
@@ -28,6 +28,7 @@ import android.os.Bundle;
 import android.util.Log;
 
 import org.eyeseetea.malariacare.database.model.Program;
+import org.eyeseetea.malariacare.database.model.Survey;
 import org.eyeseetea.malariacare.database.model.User;
 import org.eyeseetea.malariacare.database.utils.PopulateDB;
 import org.eyeseetea.malariacare.database.utils.Session;
@@ -79,6 +80,14 @@ public class DashboardActivity extends BaseActivity {
         AsyncPopulateDB asyncPopulateDB=new AsyncPopulateDB();
         asyncPopulateDB.execute((Void) null);
     }
+
+    @Override
+    protected void onRestart() {
+        super.onRestart();
+        Log.i(TAG, "onRestart");
+        Survey.removeInProgress();
+    }
+
 
     @Override
     public void onPause(){

--- a/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
@@ -76,7 +76,6 @@ public class DashboardActivity extends BaseActivity {
     public void onResume(){
         Log.d(TAG, "onResume");
         super.onResume();
-
         AsyncPopulateDB asyncPopulateDB=new AsyncPopulateDB();
         asyncPopulateDB.execute((Void) null);
         Survey.removeInProgress();

--- a/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
@@ -79,6 +79,7 @@ public class DashboardActivity extends BaseActivity {
 
         AsyncPopulateDB asyncPopulateDB=new AsyncPopulateDB();
         asyncPopulateDB.execute((Void) null);
+        Survey.removeInProgress();
     }
 
     @Override

--- a/app/src/main/java/org/eyeseetea/malariacare/database/model/Survey.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/model/Survey.java
@@ -45,11 +45,6 @@ public class Survey extends SugarRecord<Survey> {
             " where v.survey=?"+
             " and q.question=0"+
             " and v.value is not null and v.value<>''";
-    private static final String DELETE_SURVEY_IN_PROGRESS ="delete from value v"+
-            " left join question q on v.question=q.id"+
-            " where v.survey=?"+
-            " and q.question=0"+
-            " and v.value is not null and v.value<>''";
 
     OrgUnit orgUnit;
     Program program;
@@ -448,7 +443,7 @@ public class Survey extends SugarRecord<Survey> {
     public static void removeInProgress() {
         List<Survey> inProgressSurvey= Select.from(Survey.class)
                 .where(com.orm.query.Condition.prop("status").eq(Constants.SURVEY_IN_PROGRESS)).list();
-        for(int i=0;i<inProgressSurvey.size();i++){
+        for(int i=inProgressSurvey.size()-1;i>=0;i--){
             inProgressSurvey.get(i).delete();
         }
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/database/model/Survey.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/model/Survey.java
@@ -45,6 +45,11 @@ public class Survey extends SugarRecord<Survey> {
             " where v.survey=?"+
             " and q.question=0"+
             " and v.value is not null and v.value<>''";
+    private static final String DELETE_SURVEY_IN_PROGRESS ="delete from value v"+
+            " left join question q on v.question=q.id"+
+            " where v.survey=?"+
+            " and q.question=0"+
+            " and v.value is not null and v.value<>''";
 
     OrgUnit orgUnit;
     Program program;
@@ -438,5 +443,13 @@ public class Survey extends SugarRecord<Survey> {
                 ", completionDate=" + completionDate +
                 ", status=" + status +
                 '}';
+    }
+
+    public static void removeInProgress() {
+        List<Survey> inProgressSurvey= Select.from(Survey.class)
+                .where(com.orm.query.Condition.prop("status").eq(Constants.SURVEY_IN_PROGRESS)).list();
+        for(int i=0;i<inProgressSurvey.size();i++){
+            inProgressSurvey.get(i).delete();
+        }
     }
 }


### PR DESCRIPTION
At this moment:
If the aplication is onResume or onRestart and have a incomplete survey for send, the survey will be removed.
I tried to call in the middle of one survey. And the survey come back to the first screen, it is independent of this funcionality.