### PR TITLE
Remove backPressed on survey review backbutton

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
@@ -347,8 +347,9 @@ public class DashboardActivity extends BaseActivity {
         tabHost.getTabWidget().setVisibility(View.VISIBLE);
         ScoreRegister.clear();
         boolean isSent=false;
-        if(isBackPressed){
+        if(Session.getSurvey()!=null)
             isSent=Session.getSurvey().isSent();
+        if(isBackPressed){
             beforeExit();
         }
         surveyFragment.unregisterReceiver();

--- a/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
@@ -192,6 +192,7 @@ public class DashboardActivity extends BaseActivity {
     }
 
     public void initSurvey(){
+        isBackPressed=false;
         tabHost.getTabWidget().setVisibility(View.GONE);
         int  mStackLevel=0;
         mStackLevel++;

--- a/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
@@ -339,8 +339,6 @@ public class DashboardActivity extends BaseActivity {
                         }
                     }).create().show();
         }else{
-            //Reload data using service
-            isBackPressed=true;
             closeSurveyFragment();
         }
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/DynamicTabAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/DynamicTabAdapter.java
@@ -761,6 +761,7 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
         AlertDialog.Builder msgConfirmation = new AlertDialog.Builder((activity))
                 .setTitle(R.string.survey_title_completed)
                 .setMessage(R.string.survey_info_completed)
+                .setCancelable(false)
                 .setPositiveButton(R.string.send, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int arg1) {
                         hideKeyboard(PreferencesState.getInstance().getContext());


### PR DESCRIPTION
when you close a survey in sentfragment and the isBackPressed is set as true, the next new survey completed  will be removed and not send.
It is solved in this PR.