### PR TITLE
Make buddybuild post-clone script to use 2.25 sdk branch instead of 2…

### DIFF
--- a/buddybuild_postclone.sh
+++ b/buddybuild_postclone.sh
@@ -9,9 +9,5 @@ sh ${gitPath}/generate_last_commit.sh
 
 # Use the EST SDK branch
 cd sdk
-git checkout 2.22_EyeSeeTea
+git checkout 2.25_EyeSeeTea
 cd -
-cd DBFlowORM
-git checkout update_to_gradle_2.0
-cd -
-cp -a DBFlowORM sdk


### PR DESCRIPTION
closes #917 