### PR TITLE
Remove small and xsmall fonts

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
@@ -29,13 +29,10 @@ import android.util.Log;
 import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.domain.entity.Credentials;
 import org.eyeseetea.malariacare.utils.Constants;
-import org.eyeseetea.malariacare.views.FontUtils;
 
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
 
 /**
  * Singleton that holds info related to preferences

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
@@ -29,6 +29,7 @@ import android.util.Log;
 import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.domain.entity.Credentials;
 import org.eyeseetea.malariacare.utils.Constants;
+import org.eyeseetea.malariacare.views.FontUtils;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -72,10 +73,6 @@ public class PreferencesState {
      * Specified DHIS2 Server
      */
     private String dhisURL;
-    /**
-     * Map that holds the relationship between a scale and a set of dimensions
-     */
-    private Map<String, Map<String, Float>> scaleDimensionsMap;
 
     private PreferencesState() {
     }
@@ -106,7 +103,6 @@ public class PreferencesState {
 
     public void init(Context context) {
         this.context = context;
-        scaleDimensionsMap = initScaleDimensionsMap();
         reloadPreferences();
     }
 
@@ -181,57 +177,10 @@ public class PreferencesState {
                 false);
     }
 
-    /**
-     * Inits maps of dimensions
-     */
-    private Map<String, Map<String, Float>> initScaleDimensionsMap() {
-        Map<String, Float> xsmall = new HashMap<>();
-        String xsmallKey = instance.getContext().getString(R.string.font_size_level0),
-                smallKey = context.getString(R.string.font_size_level1),
-                mediumKey = context.getString(R.string.font_size_level2),
-                largeKey = context.getString(R.string.font_size_level3),
-                xlargeKey = context.getString(R.string.font_size_level4);
-
-        xsmall.put(xsmallKey, context.getResources().getDimension(R.dimen.xsmall_xsmall_text_size));
-        xsmall.put(smallKey, context.getResources().getDimension(R.dimen.xsmall_small_text_size));
-        xsmall.put(mediumKey, context.getResources().getDimension(R.dimen.xsmall_medium_text_size));
-        xsmall.put(largeKey, context.getResources().getDimension(R.dimen.xsmall_large_text_size));
-        xsmall.put(xlargeKey, context.getResources().getDimension(R.dimen.xsmall_xlarge_text_size));
-        Map<String, Float> small = new HashMap<>();
-        small.put(xsmallKey, context.getResources().getDimension(R.dimen.small_xsmall_text_size));
-        small.put(smallKey, context.getResources().getDimension(R.dimen.small_small_text_size));
-        small.put(mediumKey, context.getResources().getDimension(R.dimen.small_medium_text_size));
-        small.put(largeKey, context.getResources().getDimension(R.dimen.small_large_text_size));
-        small.put(xlargeKey, context.getResources().getDimension(R.dimen.small_xlarge_text_size));
-        Map<String, Float> medium = new HashMap<>();
-        medium.put(xsmallKey, context.getResources().getDimension(R.dimen.medium_xsmall_text_size));
-        medium.put(smallKey, context.getResources().getDimension(R.dimen.medium_small_text_size));
-        medium.put(mediumKey, context.getResources().getDimension(R.dimen.medium_medium_text_size));
-        medium.put(largeKey, context.getResources().getDimension(R.dimen.medium_large_text_size));
-        medium.put(xlargeKey, context.getResources().getDimension(R.dimen.medium_xlarge_text_size));
-        Map<String, Float> large = new HashMap<>();
-        large.put(xsmallKey, context.getResources().getDimension(R.dimen.large_xsmall_text_size));
-        large.put(smallKey, context.getResources().getDimension(R.dimen.large_small_text_size));
-        large.put(mediumKey, context.getResources().getDimension(R.dimen.large_medium_text_size));
-        large.put(largeKey, context.getResources().getDimension(R.dimen.large_large_text_size));
-        large.put(xlargeKey, context.getResources().getDimension(R.dimen.large_xlarge_text_size));
-        Map<String, Float> xlarge = new HashMap<>();
-        xlarge.put(xsmallKey, context.getResources().getDimension(R.dimen.extra_xsmall_text_size));
-        xlarge.put(smallKey, context.getResources().getDimension(R.dimen.extra_small_text_size));
-        xlarge.put(mediumKey, context.getResources().getDimension(R.dimen.extra_medium_text_size));
-        xlarge.put(largeKey, context.getResources().getDimension(R.dimen.extra_large_text_size));
-        xlarge.put(xlargeKey, context.getResources().getDimension(R.dimen.extra_xlarge_text_size));
-
-        Map scaleDimensionsMap = new HashMap<>();
-        scaleDimensionsMap.put(xsmallKey, xsmall);
-        scaleDimensionsMap.put(smallKey, small);
-        scaleDimensionsMap.put(mediumKey, medium);
-        scaleDimensionsMap.put(largeKey, large);
-        scaleDimensionsMap.put(xlargeKey, xlarge);
-        return scaleDimensionsMap;
-    }
-
     public String getScale() {
+        if (scale == null) {
+            scale = initScale();
+        }
         return scale;
     }
 
@@ -253,10 +202,6 @@ public class PreferencesState {
 
     public void setIsNewServerUrl(boolean value) {
         this.isNewServerUrl = value;
-    }
-
-    public Float getFontSize(String scale, String dimension) {
-        return scaleDimensionsMap.get(scale).get(dimension);
     }
 
     public String getOrgUnit() {

--- a/app/src/main/java/org/eyeseetea/malariacare/views/FontUtils.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/FontUtils.java
@@ -10,11 +10,7 @@ public class FontUtils {
     public static void applyFontStyleByPreference(Resources resources, Resources.Theme theme) {
         String scale = PreferencesState.getInstance().getScale();
 
-        if (scale.equals(resources.getString(R.string.font_size_level0))) {
-            theme.applyStyle(R.style.FontStyle_XSmall, true);
-        } else if (scale.equals(resources.getString(R.string.font_size_level1))) {
-            theme.applyStyle(R.style.FontStyle_Small, true);
-        } else if (scale.equals(resources.getString(R.string.font_size_level2))) {
+        if (scale.equals(resources.getString(R.string.font_size_level2))) {
             theme.applyStyle(R.style.FontStyle_Medium, true);
         } else if (scale.equals(resources.getString(R.string.font_size_level3))) {
             theme.applyStyle(R.style.FontStyle_Large, true);

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -80,15 +80,11 @@
     <string name="improve" translatable="false">Improve</string>
     <string name="monitor" translatable="false">Monitor</string>
     <string-array name="settings_array_titles_font_sizes" translatable="false">
-        <item>@string/font_extra_small</item>
-        <item>@string/font_small</item>
         <item>@string/font_medium</item>
         <item>@string/font_large</item>
         <item>@string/font_extra_large</item>
     </string-array>
     <string-array name="settings_array_values_font_sizes" translatable="false">
-        <item>@string/font_size_level0</item>
-        <item>@string/font_size_level1</item>
         <item>@string/font_size_level2</item>
         <item>@string/font_size_level3</item>
         <item>@string/font_size_level4</item>


### PR DESCRIPTION
Related #396 is incomplete.
Solved in this PR:
- [x] Font size extra small & small doesn't make sense. They must be removed 
Not solved:
- [ ] When you select large font size, you put the phone landscape, click on a question to make the keyboard appear and then rotate the phone...the app crahses 
- [ ] In general, when the app is not in default font size, the app crashes from time to time.


@ifoche i solve a related bug in skd in this PR: https://github.com/EyeSeeTea/sdk/pull/3