### PR TITLE
Feature fix move quarantine surveys from sentfragment to unsentfragment

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/model/Survey.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/model/Survey.java
@@ -568,6 +568,7 @@ public class Survey extends BaseModel implements VisitableToSDK {
     public static List<Survey> findSentSurveysAfterDate(Date minDateForMonitor) {
         return new Select().from(Survey.class)
                 .where(Survey_Table.status.eq(Constants.SURVEY_SENT))
+                .or(Survey_Table.status.eq(Constants.SURVEY_CONFLICT))
                 .and(Survey_Table.event_date.greaterThanOrEq(
                         minDateForMonitor)).queryList();
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/model/Survey.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/model/Survey.java
@@ -335,8 +335,6 @@ public class Survey extends BaseModel implements VisitableToSDK {
                         .isNot(Constants.SURVEY_SENT))
                 .and(Survey_Table.status.withTable(surveyAlias)
                         .isNot(Constants.SURVEY_CONFLICT))
-                .and(Survey_Table.status.withTable(surveyAlias)
-                        .isNot(Constants.SURVEY_QUARANTINE))
                 .and(Program_Table.uid_program.withTable(programAlias)
                         .is(malariaProgramUid))
                 .orderBy(OrderBy.fromProperty(Survey_Table.event_date.withTable(surveyAlias)))
@@ -361,7 +359,7 @@ public class Survey extends BaseModel implements VisitableToSDK {
                                 .and(Survey_Table.status.withTable(surveyAlias)
                                         .is(Constants.SURVEY_SENT))
                                 .or(Survey_Table.status.withTable(surveyAlias)
-                                        .is(Constants.SURVEY_QUARANTINE))))
+                                        .is(Constants.SURVEY_CONFLICT))))
                 .orderBy(Survey_Table.event_date, false).queryList();
     }
 


### PR DESCRIPTION
Closes #1155
@ifoche 
I modified the survey workflow to this:

Unsent fragment. Survey status: in progress, complete, sending, quarantine

Sent fragment. Survey status:  sent, conflict

Monitoring fragment. Survey status:  sent, conflict


before:

Unsent  fragment. Survey status:  in progress, complete, sending

Sent fragment. Survey status: sent, quarantine

Monitoring fragment. Survey status:  sent