### PR TITLE
Feature metadata bug

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/BaseActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/BaseActivityStrategy.java
@@ -316,6 +316,7 @@ public class BaseActivityStrategy extends ABaseActivityStrategy {
 
     private void showLoginIfConfigFileObsolete(Intent intent) {
         if (intent.getBooleanExtra(PushServiceStrategy.SHOW_LOGIN, false)) {
+            SurveyFragment.closeKeyboard();
             showLogin(true);
         }
     }

--- a/app/src/ereferrals/res/values-ne/strings.xml
+++ b/app/src/ereferrals/res/values-ne/strings.xml
@@ -751,7 +751,7 @@
 <string name="ws_unknown_exception">"अज्ञात अपवाद।"</string>
 <string name="feedback_view_image">"तस्वीर खोल्नुहोस् ..."</string>
 <string name="drive_title">"ड्राइभ मूल फोल्डर"</string>
-<string name="new_survey_disable">"नयाँ संस्करणको मेटाडाटा स्थापना गर्न सकिएन किनकि त्यहाँ पठाउन बाँकी सर्वेक्षणहरू छन् । नयाँ सर्वेक्षण बटम अस्थायी रूपमा निस्क्रिय गरिएको छ । "</string>
+<string name="new_survey_disable">"नयाँ सर्वेक्षण बटन अस्थायी रूपमा असक्षम गरिएको छ किनभने मेटाडाटाको नयाँ संस्करण सही तरिकाले स्थापना गर्न सकिएन।"</string>
 <string name="config_version">"\"Config संस्करण:% s "</string>
 <string name="av_progress">"सामग्री डाउनलोड गर्दै ... कृपया प्रतीक्षा गर्नुहोस्"</string>
 <string name="ipc_issueEntry_q_eventType">"भरिएको बेला"</string>

--- a/app/src/ereferrals/res/values-pt/strings.xml
+++ b/app/src/ereferrals/res/values-pt/strings.xml
@@ -747,7 +747,7 @@
 <string name="ws_unknown_exception">"Excepção desconhecida"</string>
 <string name="feedback_view_image">"Abrir imagen com…"</string>
 <string name="drive_title">"Unidade pasta principal"</string>
-<string name="new_survey_disable">"A nova versão de metadata não foi instalada porque há formulários pendentes por enviar. O botão do novo formulário temporariamente desabilitado."</string>
+<string name="new_survey_disable">"O novo botão de pesquisa está temporariamente desativado porque a nova versão dos metadados não pôde ser instalada corretamente."</string>
 <string name="config_version">"Config versão: %s"</string>
 <string name="av_progress">"Baixando conteúdo…por favor aguarde"</string>
 <string name="ipc_issueEntry_q_eventType">"Preenchido durante"</string>

--- a/app/src/ereferrals/res/values-sw/strings.xml
+++ b/app/src/ereferrals/res/values-sw/strings.xml
@@ -177,7 +177,7 @@
     <string name="drive_title">Kör rotmapp</string>
     <string name="config_version">Config Version: %s \n</string>
     <string name="av_progress">Hämtar innehåll ... vänligen vänta</string>
-    <string name="new_survey_disable">Toleo jipya la metadata halikuweza kufungwa kwa sababu kuna tafiti zinazojitokeza kutuma. Kipindi kipya cha utafiti kinazima</string>
+    <string name="new_survey_disable">Den nya undersökningsknappen är tillfälligt inaktiverad eftersom den nya versionen av metadata inte kunde installeras korrekt.</string>
 
 
     <!-- TERMS FROM POEDITOR -->

--- a/app/src/ereferrals/res/values/strings.xml
+++ b/app/src/ereferrals/res/values/strings.xml
@@ -905,7 +905,7 @@
 <string name="ws_unknown_exception">"Unknown exception."</string>
 <string name="feedback_view_image">"Open image with..."</string>
 <string name="drive_title">"Drive root folder"</string>
-0string name="new_survey_disable">"The new survey button is temporarily disabled because the new version of the metadata could not be installed correctly.."</string>
+<string name="new_survey_disable">"The new survey button is temporarily disabled because the new version of the metadata could not be installed correctly."</string>
 <string name="config_version">"Config Version: %s
 "</string>
 <string name="av_progress">"Downloading content... please wait"</string>

--- a/app/src/ereferrals/res/values/strings.xml
+++ b/app/src/ereferrals/res/values/strings.xml
@@ -905,7 +905,7 @@
 <string name="ws_unknown_exception">"Unknown exception."</string>
 <string name="feedback_view_image">"Open image with..."</string>
 <string name="drive_title">"Drive root folder"</string>
-<string name="new_survey_disable">"The new version of metadata could not be installed because there are pending surveys to send. The new survey button temporarily disable"</string>
+0string name="new_survey_disable">"The new survey button is temporarily disabled because the new version of the metadata could not be installed correctly.."</string>
 <string name="config_version">"Config Version: %s
 "</string>
 <string name="av_progress">"Downloading content... please wait"</string>

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/SurveyFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/SurveyFragment.java
@@ -122,7 +122,6 @@ public class SurveyFragment extends Fragment {
     @Override
     public void onPause() {
         Log.d(TAG, "onPause");
-        closeKeyboard();
         if (!DashboardActivity.dashboardActivity.isLoadingReview()
                 && !areActiveSurveysInQuarantine()) {
             beforeExit();

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/SurveyFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/SurveyFragment.java
@@ -39,6 +39,7 @@ import org.eyeseetea.malariacare.domain.exception.LoadingSurveyException;
 import org.eyeseetea.malariacare.layout.adapters.survey.DynamicTabAdapter;
 import org.eyeseetea.malariacare.layout.adapters.survey.navigation.NavigationBuilder;
 import org.eyeseetea.malariacare.strategies.DashboardHeaderStrategy;
+import org.eyeseetea.malariacare.views.question.CommonQuestionView;
 import org.eyeseetea.sdk.presentation.views.CustomTextView;
 
 import java.util.ArrayList;
@@ -70,6 +71,7 @@ public class SurveyFragment extends Fragment {
      * Parent view of main content
      */
     private LinearLayout content;
+    private static ListView listView;
 
     public static void nextProgressMessage() {
         if (DashboardActivity.dashboardActivity != null) {
@@ -120,6 +122,7 @@ public class SurveyFragment extends Fragment {
     @Override
     public void onPause() {
         Log.d(TAG, "onPause");
+        closeKeyboard();
         if (!DashboardActivity.dashboardActivity.isLoadingReview()
                 && !areActiveSurveysInQuarantine()) {
             beforeExit();
@@ -142,6 +145,13 @@ public class SurveyFragment extends Fragment {
 
     private void beforeExit() {
         DashboardActivity.dashboardActivity.beforeExit();
+    }
+
+    public static void  closeKeyboard(){
+        Log.d(TAG, "close keyboard");
+        if(listView!=null) {
+            CommonQuestionView.hideKeyboard(listView.getContext(), listView);
+        }
     }
 
     /**
@@ -220,11 +230,11 @@ public class SurveyFragment extends Fragment {
             content.removeAllViews();
             content.addView(viewContent);
 
-            ListView listViewTab = (ListView) llLayout.findViewById(R.id.listView);
+            listView = (ListView) llLayout.findViewById(R.id.listView);
 
-            dynamicTabAdapter.addOnSwipeListener(listViewTab);
+            dynamicTabAdapter.addOnSwipeListener(listView);
 
-            listViewTab.setAdapter(dynamicTabAdapter);
+            listView.setAdapter(dynamicTabAdapter);
 
             hideProgress();
         }catch (NullPointerException e){


### PR DESCRIPTION
closes #2140 
I can´t replicate the keyboard bug. When refresh metadata the keyboard is always closed. 

the second point, i think it is solved changing the toast text.