### PR TITLE
increase x5 ereferals timeout

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/exporter/eReferralsAPIClient.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/exporter/eReferralsAPIClient.java
@@ -36,7 +36,7 @@ public class eReferralsAPIClient {
     private SurveyApiClientRetrofit mSurveyApiClientRetrofit;
     private OkHttpClient mOkHttpClient;
     public String mBaseAddress;
-    private final int DEFAULT_TIMEOUT = 10000;
+    private final int DEFAULT_TIMEOUT = 50000;
 
     public eReferralsAPIClient(String baseAddress) throws IllegalArgumentException {
         mBaseAddress = baseAddress;


### PR DESCRIPTION
Closes #2136 
The problem is server timeout.
I increased the app timeout to solve it waiting for the server response.
But i think we should create a quarentine system to ereferals to avoid duplicates. But we would need a call to ask for the surveys info in the webservice.

to replicate this bug :
User: MZ_TEST_IPC
server: https://clone.psi-mis.org
webservice: https://apps.psi-mis.org/eRefWSTrain/
web url(in settings): https://apps.psi-mis.org/connect-train/