### PR TITLE
fix phone reg exp validation

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/views/question/multiquestion/strategies/PhoneMultiquestionViewStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/views/question/multiquestion/strategies/PhoneMultiquestionViewStrategy.java
@@ -41,8 +41,7 @@ public class PhoneMultiquestionViewStrategy extends APhoneMultiquestionViewStrat
                         try {
                             Phone phone = new Phone(phoneText.getText().toString(), phoneFormat);
                             notifyAnswerChanged(phone.getValue());
-                            Validation.getInstance().removeInputError(phoneText);
-
+                            validateRegExp(phoneText, phone);
                         } catch (InvalidPhoneException e) {
                             Validation.getInstance().addinvalidInput(phoneText,
                                     mPhoneMultiQuestionView.getContext().getString(

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/strategies/APhoneMultiquestionViewStrategy.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/strategies/APhoneMultiquestionViewStrategy.java
@@ -50,7 +50,7 @@ public abstract class APhoneMultiquestionViewStrategy  {
         });
     }
 
-    public void validatePhone(EditText phoneText) throws InvalidPhoneException {
+    private void validatePhone(EditText phoneText) throws InvalidPhoneException {
         Phone phone = new Phone(phoneText.getText().toString());
         validateRegExp(phoneText, phone);
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/strategies/APhoneMultiquestionViewStrategy.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/strategies/APhoneMultiquestionViewStrategy.java
@@ -30,11 +30,7 @@ public abstract class APhoneMultiquestionViewStrategy  {
             @Override
             public void afterTextChanged(Editable s) {
                 try {
-                    Phone phone = new Phone(phoneText.getText().toString());
-                    if(mPhoneMultiQuestionView.validateQuestionRegExp(phoneText)) {
-                        notifyAnswerChanged(phone.getValue());
-                        Validation.getInstance().removeInputError(phoneText);
-                    }
+                    validatePhone(phoneText);
                 } catch (InvalidPhoneException e) {
                     Validation.getInstance().addinvalidInput(phoneText,
                             mPhoneMultiQuestionView.getContext().getString(
@@ -52,6 +48,18 @@ public abstract class APhoneMultiquestionViewStrategy  {
 
             }
         });
+    }
+
+    public void validatePhone(EditText phoneText) throws InvalidPhoneException {
+        Phone phone = new Phone(phoneText.getText().toString());
+        validateRegExp(phoneText, phone);
+    }
+
+    protected void validateRegExp(EditText phoneText, Phone phone) {
+        if(mPhoneMultiQuestionView.validateQuestionRegExp(phoneText)) {
+            notifyAnswerChanged(phone.getValue());
+            Validation.getInstance().removeInputError(phoneText);
+        }
     }
 
     protected void notifyAnswerChanged(String value) {


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://github.com/EyeSeeTea/pictureapp/issues/2257

### :tophat: What is the goal?

Fix the phone Regexp validation

### :memo: How is it being implemented?

Added the regexp validation method after change phone edittext value.

### :boom: How can it be tested?

- [ ] **Use Case 1:**  

You need login in the clone server with a phone question with regexp added. And in the app write for example: "+0123456789" (the  valid regexp added for me in the follow .json is \d{10}, the national number 0123456789 and the international number + *) You should see a different error input in the phone field.
To config the 8001 user in clone server:
method PUT
Url: https://clone.psi-mis.org/api/dataStore/Connect_config/dc@TZ@v4
Body:
```
{
	"countryCode": "TZ",
	"program": "FPL+A360-Ado+A360-Par",
	"actionType": "issueReferral",
	"version": "4",
	"updateDate": "2018-03-07 11:50",
	"updateUser": "BR",
	"languages": [
		"en",
		"sw"
	],
	"issuing_capture": {
		"validSamples": [],
		"payloadSpecs": [{
				"dataPointRef": "url"
			},
			{
				"dataPointRef": "version"
			},
			{
				"dataPointRef": "csvVersion"
			},
			{
				"dataPointRef": "source"
			},
			{
				"dataPointRef": "androidInfo"
			},
			{
				"dataPointRef": "language"
			},
			{
				"dataPointRef": "userName"
			},
			{
				"dataPointRef": "password"
			},
			{
				"dataPointRef": "settings",
				"mandatory": "false"
			},
			{
				"dataPointRef": "type"
			},
			{
				"dataPointRef": "actionId"
			},
			{
				"dataPointRef": "sourceAddedDateTime"
			},
			{
				"dataPointRef": "voucher"
			},
			{
				"dataPointRef": "coordinates"
			}
		],
		"dataValuesSpecs": [{
				"dataPointRef": "program",
				"poTerm": "ipc_issueEntry_q_program",
				"defaultName": "Program",
				"controlType": "DROPDOWN_LIST",
				"options": [{
						"value": "FPL",
						"poTerm": "common_option_program_familyPlanning_familia",
						"defaultName": "Familia"
					},
					{
						"value": "FPL-A360-ADO",
						"poTerm": "common_option_program_familyPlanning_a360adolsecents",
						"defaultName": "Kuwa Mjanja - Girls"
					},
					{
						"value": "FPL-A360-PAR",
						"poTerm": "common_option_program_familyPlanning_a360parents",
						"defaultName": "Kuwa Mjanja - Parents"
					}
				]
			},
			{
				"dataPointRef": "firstName",
				"poTerm": "ipc_issueEntry_q_firstName",
				"defaultName": "First name",
				"controlType": "SHORT_TEXT",
				"queueDisplayPriority": "IMPORTANT"
			},
			{
				"dataPointRef": "lastName",
				"poTerm": "ipc_issueEntry_q_lastName",
				"defaultName": "Last name",
				"controlType": "SHORT_TEXT",
				"queueDisplayPriority": "IMPORTANT"
			},
			{
				"dataPointRef": "gender",
				"poTerm": "ipc_issueEntry_q_gender",
				"defaultName": "Gender",
				"controlType": "DROPDOWN_LIST",
				"options": [{
						"value": "F",
						"poTerm": "common_option_gender_female",
						"defaultName": "Female"
					},
					{
						"value": "M",
						"poTerm": "common_option_gender_male",
						"defaultName": "Male"
					}
				]
			},
			{
				"dataPointRef": "adolescentDaughters",
				"poTerm": "ipc_issueEntry_q_adolescentDaughters",
				"defaultName": "# Daughters 15-19 y/o",
				"controlType": "INT"
			},
			{
				"dataPointRef": "motherName",
				"poTerm": "ipc_issueEntry_q_motherName",
				"defaultName": "First name of mother",
				"controlType": "SHORT_TEXT"
			},
			{
				"dataPointRef": "birthDistrict",
				"poTerm": "ipc_issueEntry_q_birthDistrict",
				"defaultName": "District of birth",
				"controlType": "SHORT_TEXT"
			},
			{
				"dataPointRef": "yearOfBirth",
				"poTerm": "ipc_issueEntry_q_yearOfBirth",
				"defaultName": "Year of Birth",
				"controlType": "YEAR"
			},
			{
				"dataPointRef": "civilStatus",
				"poTerm": "ipc_issueEntry_q_civilStatus",
				"defaultName": "Marital status ",
				"controlType": "DROPDOWN_LIST",
				"options": [{
						"value": "MAR",
						"poTerm": "common_option_civilStatus_married",
						"defaultName": "Married"
					},
					{
						"value": "UNMAR",
						"poTerm": "common_option_civilStatus_unmarried",
						"defaultName": "Unmarried"
					},
					{
						"value": "DIV",
						"poTerm": "common_option_civilStatus_divorced",
						"defaultName": "Divorced"
					},
					{
						"value": "WID",
						"poTerm": "common_option_civilStatus_widowed",
						"defaultName": "Widowed"
					}
				]
			},
			{
				"dataPointRef": "noOfLivingChildren",
				"poTerm": "ipc_issueEntry_q_numberOfChildren",
				"defaultName": "Number of living children",
				"controlType": "INT"
			},
			{
				"dataPointRef": "ageYoungest",
				"poTerm": "ipc_issueEntry_afterIssuing_q1_title",
				"defaultName": "Age of youngest child",
				"controlType": "DROPDOWN_LIST",
				"options": [{
						"value": "0-6M",
						"poTerm": "ipc_issueEntry_afterIssuing_q1_option1",
						"defaultName": "0 - 6 months"
					},
					{
						"value": "6-12M",
						"poTerm": "ipc_issueEntry_afterIssuing_q1_option2",
						"defaultName": "6 - 12 months"
					},
					{
						"value": "1-2Y",
						"poTerm": "ipc_issueEntry_afterIssuing_q1_option3",
						"defaultName": "1 - 2 years"
					},
					{
						"value": "2+Y",
						"poTerm": "ipc_issueEntry_afterIssuing_q1_option4",
						"defaultName": "Above 2 years"
					}
				]
			},
			{
				"dataPointRef": "segment",
				"poTerm": "ipc_issueEntry_q_TZA360_segment",
				"defaultName": "Segment",
				"controlType": "DROPDOWN_LIST",
				"options": [{
						"value": "Farida",
						"poTerm": "common_option_TZA360_segment_farida",
						"defaultName": "Farida"
					},
					{
						"value": "Bahati",
						"poTerm": "common_option_TZA360_segment_bahati",
						"defaultName": "Bahati"
					},
					{
						"value": "Pendo",
						"poTerm": "common_option_TZA360_segment_pendo",
						"defaultName": "Pendo"
					},
					{
						"value": "Furaha",
						"poTerm": "common_option_TZA360_segment_furaha",
						"defaultName": "Furaha"
					},
					{
						"value": "ND",
						"poTerm": "common_option_TZA360_segment_nd",
						"defaultName": "Not determined"
					}
				]
			},
			{
				"dataPointRef": "currentMethod",
				"poTerm": "ipc_issueEntry_q_currentMethod",
				"defaultName": "Current method",
				"controlType": "DROPDOWN_LIST",
				"options": [{
						"value": "NON",
						"poTerm": "common_option_method_none",
						"defaultName": "None"
					},
					{
						"value": "CON",
						"poTerm": "common_option_method_condom",
						"defaultName": "Condom"
					},
					{
						"value": "PIL",
						"poTerm": "common_option_method_pills",
						"defaultName": "Pills"
					},
					{
						"value": "INJ",
						"poTerm": "common_option_method_injection",
						"defaultName": "Injection"
					},
					{
						"value": "IMP",
						"poTerm": "common_option_method_implant",
						"defaultName": "Implant"
					},
					{
						"value": "IUD",
						"poTerm": "common_option_method_iud",
						"defaultName": "IUD"
					},
					{
						"value": "OTH",
						"poTerm": "common_option_method_other",
						"defaultName": "Other"
					}
				],
				"futureOptions": [{
					"value": "EC",
					"poTerm": "common_option_method_ec",
					"defaultName": "EC"
				}]
			},
			{
				"dataPointRef": "phoneOwnership",
				"poTerm": "ipc_issueEntry_q_ownershipOfPhone",
				"defaultName": "Phone ownership",
				"controlType": "DROPDOWN_LIST",
				"options": [{
						"value": "NO",
						"poTerm": "common_option_ownershipOfPhone_noMobile",
						"defaultName": "No Number"
					},
					{
						"value": "HER",
						"poTerm": "common_option_ownershipOfPhone_herNumber",
						"defaultName": "Her Number"
					},
					{
						"value": "MF",
						"poTerm": "common_option_ownershipOfPhone_parent",
						"defaultName": "Parent's Number"
					},
					{
						"value": "PAR",
						"poTerm": "common_option_ownershipOfPhone_husbandPartner",
						"defaultName": "Husband/Partner"
					},
					{
						"value": "SHA",
						"poTerm": "common_option_ownershipOfPhone_shared",
						"defaultName": "Shared"
					}
				]
			},
			{
				"dataPointRef": "phoneNumber",
				"poTerm": "ipc_issueEntry_q_phoneNumber",
				"defaultName": "Phone number",
				"controlType": "PHONE_NUMBER",
				"validationRegex": "^(\\d{10})$",
				"validationPoTerm": "some_error_msg_ref",
				"format": {
					"accepted": [{
							"starts": "0",
							"length": "10",
							"comment": "national"
						},
						{
							"starts": "+",
							"comment": "international"
						}
					],
					"details": {
						"trunkPrefix": "0",
						"dialingCode": "+255"
					}
				}
			},
			{
				"dataPointRef": "phoneContactConsent",
				"poTerm": "ipc_issueEntry_q_furtherInformationConsent",
				"defaultName": "Further phone contact consent",
				"controlType": "DROPDOWN_LIST",
				"options": [{
						"value": "NO",
						"poTerm": "common_option_furtherInformationConsent_no",
						"defaultName": "No"
					},
					{
						"value": "YESP",
						"poTerm": "common_option_furtherInformationConsent_yesFromPSI",
						"defaultName": "Yes - Kuwa Mjanja (PSI)"
					},
					{
						"value": "YESPP",
						"poTerm": "common_option_furtherInformationConsent_yesFromPSIAndPartners",
						"defaultName": "Yes - Kuwa Mjanja (PSI) & Partners"
					}
				]
			},
			{
				"dataPointRef": "channelReferredTo",
				"poTerm": "ipc_issueEntry_q_channelReferredTo",
				"defaultName": "Refered to which program channel?",
				"controlType": "DROPDOWN_LIST",
				"options": [{
						"value": "GCLINIC",
						"poTerm": "common_option_channelReferredTo_girlsClinic",
						"defaultName": "KM Girls Clinic"
					},
					{
						"value": "POPUP",
						"poTerm": "common_option_channelReferredTo_popup",
						"defaultName": "KM Pop-up"
					},
					{
						"value": "PROV",
						"poTerm": "common_option_channelReferredTo_provider",
						"defaultName": "Provider"
					}
				]
			}
		],
		"rulesSpecs": [{
				"conditions": [{
					"left": {
						"value": "program",
						"type": "dataPointRef"
					},
					"operator": "==",
					"right": {
						"value": "FPL",
						"type": "value"
					}
				}],
				"actions": [{
						"dataPointRef": "gender",
						"do": "SHOW"
					},
					{
						"dataPointRef": "motherName",
						"do": "SHOW"
					},
					{
						"dataPointRef": "birthDistrict",
						"do": "SHOW"
					},
					{
						"dataPointRef": "yearOfBirth",
						"do": "SHOW"
					},
					{
						"dataPointRef": "civilStatus",
						"do": "SHOW"
					},
					{
						"dataPointRef": "noOfLivingChildren",
						"do": "SHOW"
					},
					{
						"dataPointRef": "ageYoungest",
						"do": "SHOW"
					},
					{
						"dataPointRef": "currentMethod",
						"do": "SHOW"
					},
					{
						"dataPointRef": "channelOfReferral",
						"do": "SHOW"
					}
				]
			},
			{
				"conditions": [{
					"left": {
						"value": "program",
						"type": "dataPointRef"
					},
					"operator": "==",
					"right": {
						"value": "FPL-A360-ADO",
						"type": "value"
					}
				}],
				"actions": [{
						"dataPointRef": "motherName",
						"do": "SHOW"
					},
					{
						"dataPointRef": "birthDistrict",
						"do": "SHOW"
					},
					{
						"dataPointRef": "yearOfBirth",
						"do": "SHOW"
					},
					{
						"dataPointRef": "segment",
						"do": "SHOW"
					},
					{
						"dataPointRef": "currentMethod",
						"do": "SHOW"
					},
					{
						"dataPointRef": "channelReferredTo",
						"do": "SHOW"
					}
				]
			},
			{
				"conditions": [{
					"left": {
						"value": "noOfLivingChildren",
						"type": "dataPointRef"
					},
					"operator": ">",
					"right": {
						"value": "0",
						"type": "value"
					}
				}],
				"actions": [{
					"dataPointRef": "ageYoungest",
					"do": "SHOW"
				}]
			},
			{
				"conditions": [{
					"left": {
						"value": "program",
						"type": "dataPointRef"
					},
					"operator": "==",
					"right": {
						"value": "FPL-A360-PAR",
						"type": "value"
					}
				}],
				"actions": [{
						"dataPointRef": "gender",
						"do": "SHOW"
					},
					{
						"dataPointRef": "adolescentDaughters",
						"do": "SHOW"
					}
				]
			},
			{
				"conditions": [{
					"left": {
						"value": "phoneOwnership",
						"type": "dataPointRef"
					},
					"operator": "==",
					"right": {
						"value": "HER",
						"type": "value"
					}
				}],
				"actions": [{
						"dataPointRef": "phoneNumber",
						"do": "SHOW"
					},
					{
						"dataPointRef": "phoneContactConsent",
						"do": "SHOW"
					}
				]
			},
			{
				"conditions": [{
					"left": {
						"value": "phoneOwnership",
						"type": "dataPointRef"
					},
					"operator": "==",
					"right": {
						"value": "MF",
						"type": "value"
					}
				}],
				"actions": [{
						"dataPointRef": "phoneNumber",
						"do": "SHOW"
					},
					{
						"dataPointRef": "phoneContactConsent",
						"do": "SHOW"
					}
				]
			},
			{
				"conditions": [{
					"left": {
						"value": "phoneOwnership",
						"type": "dataPointRef"
					},
					"operator": "==",
					"right": {
						"value": "PAR",
						"type": "value"
					}
				}],
				"actions": [{
						"dataPointRef": "phoneNumber",
						"do": "SHOW"
					},
					{
						"dataPointRef": "phoneContactConsent",
						"do": "SHOW"
					}
				]
			},
			{
				"conditions": [{
					"left": {
						"value": "phoneOwnership",
						"type": "dataPointRef"
					},
					"operator": "==",
					"right": {
						"value": "SHA",
						"type": "value"
					}
				}],
				"actions": [{
						"dataPointRef": "phoneNumber",
						"do": "SHOW"
					},
					{
						"dataPointRef": "phoneContactConsent",
						"do": "SHOW"
					}
				]
			}
		]
	}
}

```

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
