### PR TITLE
Feature remove dhis setting and modify login server edittext

### DIFF
--- a/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/BaseActivityShould.java
+++ b/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/BaseActivityShould.java
@@ -112,7 +112,7 @@ public class BaseActivityShould {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(
                 context);
         SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.putString(context.getString(R.string.dhis_url), "http:test");
+        editor.putString(context.getString(R.string.server_url_preference_key), "http:test");
         editor.commit();
 
         Credentials credentials = new Credentials("http:test", "test", "test");
@@ -135,7 +135,7 @@ public class BaseActivityShould {
                 context);
         if (previousOrganisationCredentials != null) {
             SharedPreferences.Editor editor = sharedPreferences.edit();
-            editor.putString(context.getString(R.string.dhis_url),
+            editor.putString(context.getString(R.string.server_url_preference_key),
                     previousOrganisationCredentials.getServerURL());
             editor.commit();
         }
@@ -158,7 +158,7 @@ public class BaseActivityShould {
     }
 
     private void saveCredentials(Credentials credentials) {
-        PreferencesState.getInstance().saveStringPreference(R.string.dhis_url,
+        PreferencesState.getInstance().saveStringPreference(R.string.server_url_preference_key,
                 credentials.getServerURL());
         PreferencesState.getInstance().saveStringPreference(R.string.dhis_user,
                 credentials.getUsername());

--- a/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/data/sync/exporter/PushUseCaseShould.java
+++ b/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/data/sync/exporter/PushUseCaseShould.java
@@ -212,7 +212,7 @@ public class PushUseCaseShould {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(
                 context);
         SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.putString(context.getString(R.string.dhis_url), "test");
+        editor.putString(context.getString(R.string.server_url_preference_key), "test");
         editor.commit();
 
         Credentials credentials = new Credentials("test", "test", "test");
@@ -234,7 +234,7 @@ public class PushUseCaseShould {
                 context);
         if (previousCredentials != null) {
             SharedPreferences.Editor editor = sharedPreferences.edit();
-            editor.putString(context.getString(R.string.dhis_url),
+            editor.putString(context.getString(R.string.server_url_preference_key),
                     previousCredentials.getServerURL());
             editor.commit();
         }

--- a/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/data/sync/exporter/WSPushControllerShould.java
+++ b/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/data/sync/exporter/WSPushControllerShould.java
@@ -67,7 +67,7 @@ public class WSPushControllerShould {
     private void savePreferences() {
         Context context = PreferencesState.getInstance().getContext();
         serverPreference = (PreferenceManager.getDefaultSharedPreferences(
-                context)).getString(context.getString(R.string.dhis_url),"");
+                context)).getString(context.getString(R.string.server_url_preference_key),"");
         userPreference = (PreferenceManager.getDefaultSharedPreferences(
                 context)).getString(context.getString(R.string.logged_user_username),"");
         pinPreference = (PreferenceManager.getDefaultSharedPreferences(
@@ -82,7 +82,7 @@ public class WSPushControllerShould {
                 context);
 
         SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.putString(context.getString(R.string.dhis_url), serverPreference);
+        editor.putString(context.getString(R.string.server_url_preference_key), serverPreference);
         editor.putString(context.getString(R.string.logged_user_username), userPreference);
         editor.putString(context.getString(R.string.logged_user_pin), pinPreference);
         editor.putLong(context.getString(R.string.logged_user_program), programPreference);
@@ -96,7 +96,7 @@ public class WSPushControllerShould {
                 context);
 
         SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.putString(context.getString(R.string.dhis_url), "test");
+        editor.putString(context.getString(R.string.server_url_preference_key), "test");
         editor.commit();
 
         Credentials credentials = new Credentials("test", "test", "test");

--- a/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/services/PushServiceShould.java
+++ b/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/services/PushServiceShould.java
@@ -137,7 +137,7 @@ public class PushServiceShould {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(
                 context);
         SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.putString(context.getString(R.string.dhis_url), "test");
+        editor.putString(context.getString(R.string.server_url_preference_key), "test");
         editor.commit();
 
         Credentials credentials = new Credentials("test", "test", "test");
@@ -159,7 +159,7 @@ public class PushServiceShould {
                 context);
         if (previousCredentials != null) {
             SharedPreferences.Editor editor = sharedPreferences.edit();
-            editor.putString(context.getString(R.string.dhis_url),
+            editor.putString(context.getString(R.string.server_url_preference_key),
                     previousCredentials.getServerURL());
             editor.commit();
         }

--- a/app/src/cambodia/java/org/eyeseetea/malariacare/data/sync/exporter/strategies/ConvertToSdkVisitorStrategy.java
+++ b/app/src/cambodia/java/org/eyeseetea/malariacare/data/sync/exporter/strategies/ConvertToSdkVisitorStrategy.java
@@ -1,5 +1,6 @@
 package org.eyeseetea.malariacare.data.sync.exporter.strategies;
 
+import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.data.sync.importer.models.EventExtended;
 
 public class ConvertToSdkVisitorStrategy {

--- a/app/src/cambodia/java/org/eyeseetea/malariacare/data/sync/importer/strategies/PullControllerStrategy.java
+++ b/app/src/cambodia/java/org/eyeseetea/malariacare/data/sync/importer/strategies/PullControllerStrategy.java
@@ -2,6 +2,7 @@ package org.eyeseetea.malariacare.data.sync.importer.strategies;
 
 import org.eyeseetea.malariacare.data.sync.importer.ConvertFromSDKVisitor;
 import org.eyeseetea.malariacare.data.sync.importer.PullController;
+import org.eyeseetea.malariacare.domain.boundary.IPullController;
 
 public class PullControllerStrategy extends APullControllerStrategy {
     public PullControllerStrategy(PullController pullController) {

--- a/app/src/cambodia/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
+++ b/app/src/cambodia/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
@@ -47,6 +47,10 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
             preferenceCategory.removePreference(preferenceScreen.findPreference(
                     settingsActivity.getResources().getString(R.string.dhis_url)));
         }
+        Preference  serverUrlPreference = (Preference) preferenceScreen.findPreference(
+                preferenceScreen.getContext().getResources().getString(R.string.dhis_url));
+        serverUrlPreference.setOnPreferenceClickListener(
+                getOnPreferenceClickListener());
     }
 
     @Override
@@ -84,4 +88,9 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
 
     }
 
+    @Override
+    public void addExtraPreferences() {
+        settingsActivity.bindPreferenceSummaryToValue(
+                settingsActivity.findPreference(settingsActivity.getString(R.string.dhis_url)));
+    }
 }

--- a/app/src/cambodia/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
+++ b/app/src/cambodia/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
@@ -45,10 +45,10 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
                     (PreferenceCategory) preferenceScreen.findPreference(
                             settingsActivity.getResources().getString(R.string.pref_cat_server));
             preferenceCategory.removePreference(preferenceScreen.findPreference(
-                    settingsActivity.getResources().getString(R.string.dhis_url)));
+                    settingsActivity.getResources().getString(R.string.server_url_preference_key)));
         }
         Preference  serverUrlPreference = (Preference) preferenceScreen.findPreference(
-                preferenceScreen.getContext().getResources().getString(R.string.dhis_url));
+                preferenceScreen.getContext().getResources().getString(R.string.server_url_preference_key));
         serverUrlPreference.setOnPreferenceClickListener(
                 getOnPreferenceClickListener());
     }
@@ -91,6 +91,6 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
     @Override
     public void addExtraPreferences() {
         settingsActivity.bindPreferenceSummaryToValue(
-                settingsActivity.findPreference(settingsActivity.getString(R.string.dhis_url)));
+                settingsActivity.findPreference(settingsActivity.getString(R.string.server_url_preference_key)));
     }
 }

--- a/app/src/cambodia/java/org/eyeseetea/malariacare/strategies/SurveyFragmentStrategy.java
+++ b/app/src/cambodia/java/org/eyeseetea/malariacare/strategies/SurveyFragmentStrategy.java
@@ -3,6 +3,8 @@ package org.eyeseetea.malariacare.strategies;
 
 import static org.eyeseetea.malariacare.utils.Constants.SURVEY_SENT;
 
+import android.content.Context;
+
 import org.eyeseetea.malariacare.data.database.model.OptionDB;
 import org.eyeseetea.malariacare.data.database.model.ProgramDB;
 import org.eyeseetea.malariacare.data.database.model.QuestionDB;

--- a/app/src/cambodia/java/utils/PhoneMask.java
+++ b/app/src/cambodia/java/utils/PhoneMask.java
@@ -1,5 +1,7 @@
 package utils;
 
+import org.eyeseetea.malariacare.domain.entity.PhoneFormat;
+
 /**
  * Created by ina on 02/08/2016.
  */

--- a/app/src/cambodia/res/values/donottranslate.xml
+++ b/app/src/cambodia/res/values/donottranslate.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <item name="dhis_url" translatable="false" type="string">dhis_url</item>
     <string name="rdtPositive" translatable="false">Positive</string>
     <string name="rdtNegative" translatable="false">Negative</string>
     <string name="rdtNotTested" translatable="false">Not Tested</string>
-    <string name="DHIS_DEFAULT_SERVER" translatable="false">https://data.psi-mis.org</string>
+    <string name="default_login_url" translatable="false">https://data.psi-mis.org</string>
     <string name="work_in_progress" translatable="false">Work in progress</string>
 
 

--- a/app/src/cambodia/res/xml/pref_general.xml
+++ b/app/src/cambodia/res/xml/pref_general.xml
@@ -43,7 +43,7 @@
         android:key="@string/pref_cat_server"
         android:title="@string/server">
         <EditTextPreference
-            android:defaultValue="@string/DHIS_DEFAULT_SERVER"
+            android:defaultValue="@string/default_login_url"
             android:inputType="textUri"
             android:key="@string/dhis_url"
             android:maxLines="1"

--- a/app/src/cambodia/res/xml/pref_general.xml
+++ b/app/src/cambodia/res/xml/pref_general.xml
@@ -45,7 +45,7 @@
         <EditTextPreference
             android:defaultValue="@string/default_login_url"
             android:inputType="textUri"
-            android:key="@string/dhis_url"
+            android:key="@string/server_url_preference_key"
             android:maxLines="1"
             android:selectAllOnFocus="true"
             android:singleLine="true"

--- a/app/src/cnm/java/org/eyeseetea/malariacare/data/remote/datasource/AppInfoRemoteDataSource.java
+++ b/app/src/cnm/java/org/eyeseetea/malariacare/data/remote/datasource/AppInfoRemoteDataSource.java
@@ -18,7 +18,7 @@ public class AppInfoRemoteDataSource implements IAppInfoRepository {
     public void getAppInfo(final IDataSourceCallback<AppInfo> callback) {
         CnmApiClient cnmApiClient = null;
         try {
-            cnmApiClient = new CnmApiClient(PreferencesState.getInstance().getDhisURL() + "/");
+            cnmApiClient = new CnmApiClient(PreferencesState.getInstance().getServerURL() + "/");
         } catch (Exception e) {
             e.printStackTrace();
             callback.onError(e);

--- a/app/src/cnm/java/org/eyeseetea/malariacare/data/sync/importer/strategies/PullControllerStrategy.java
+++ b/app/src/cnm/java/org/eyeseetea/malariacare/data/sync/importer/strategies/PullControllerStrategy.java
@@ -267,7 +267,7 @@ public class PullControllerStrategy extends APullControllerStrategy {
             CnmApiClient.CnmApiClientCallBack<List<OrgUnitTree>> cnmApiClientCallBack) {
         CnmApiClient cnmApiClient = null;
         try {
-            cnmApiClient = new CnmApiClient(PreferencesState.getInstance().getDhisURL() + "/");
+            cnmApiClient = new CnmApiClient(PreferencesState.getInstance().getServerURL() + "/");
         } catch (Exception e) {
             e.printStackTrace();
             cnmApiClientCallBack.onError(e);

--- a/app/src/cnm/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
+++ b/app/src/cnm/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
@@ -71,6 +71,10 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
             preferenceVisual.removePreference(preferenceScreen.findPreference(
                     settingsActivity.getResources().getString(R.string.imei_preference)));
         }
+        Preference serverUrlPreference = (Preference) findPreference(
+                getApplicationContext().getResources().getString(R.string.dhis_url));
+        serverUrlPreference.setOnPreferenceClickListener(
+                mSettingsActivityStrategy.getOnPreferenceClickListener());
         Preference autoconfigurePreference = preferenceScreen.findPreference(
                 settingsActivity.getResources().getString(R.string.autoconfigure_preference));
         autoconfigurePreference.setOnPreferenceClickListener(
@@ -169,6 +173,12 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
     @Override
     public void onBackPressed() {
 
+    }
+
+    @Override
+    public void addExtraPreferences() {
+        settingsActivity.bindPreferenceSummaryToValue(
+                settingsActivity.findPreference(settingsActivity.getString(R.string.dhis_url)));
     }
 
     @Override

--- a/app/src/cnm/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
+++ b/app/src/cnm/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
@@ -64,17 +64,19 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
                     (PreferenceCategory) preferenceScreen.findPreference(
                             settingsActivity.getResources().getString(R.string.pref_cat_server));
             preferenceCategory.removePreference(preferenceScreen.findPreference(
-                    settingsActivity.getResources().getString(R.string.dhis_url)));
+                    settingsActivity.getResources().getString(R.string.server_url_preference_key)));
             PreferenceCategory preferenceVisual =
                     (PreferenceCategory) preferenceScreen.findPreference(
                             settingsActivity.getResources().getString(R.string.pref_visual));
             preferenceVisual.removePreference(preferenceScreen.findPreference(
                     settingsActivity.getResources().getString(R.string.imei_preference)));
+        } else {
+            Preference serverUrlPreference = preferenceScreen.findPreference(
+                    preferenceScreen.getContext().getResources().getString(
+                            R.string.server_url_preference_key));
+                serverUrlPreference.setOnPreferenceClickListener(
+                        getOnPreferenceClickListener());
         }
-        Preference serverUrlPreference = (Preference) findPreference(
-                getApplicationContext().getResources().getString(R.string.dhis_url));
-        serverUrlPreference.setOnPreferenceClickListener(
-                mSettingsActivityStrategy.getOnPreferenceClickListener());
         Preference autoconfigurePreference = preferenceScreen.findPreference(
                 settingsActivity.getResources().getString(R.string.autoconfigure_preference));
         autoconfigurePreference.setOnPreferenceClickListener(
@@ -177,8 +179,10 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
 
     @Override
     public void addExtraPreferences() {
-        settingsActivity.bindPreferenceSummaryToValue(
-                settingsActivity.findPreference(settingsActivity.getString(R.string.dhis_url)));
+        Preference serverPreference = settingsActivity.findPreference(settingsActivity.getString(R.string.server_url_preference_key));
+        if(serverPreference!=null){
+            settingsActivity.bindPreferenceSummaryToValue(serverPreference);
+        }
     }
 
     @Override

--- a/app/src/cnm/res/values/donottranslate.xml
+++ b/app/src/cnm/res/values/donottranslate.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <item name="dhis_url" translatable="false" type="string">dhis_url</item>
     <string name="rdtPositive" translatable="false">Positive</string>
     <string name="rdtNegative" translatable="false">Negative</string>
     <string name="rdtNotTested" translatable="false">Not Tested</string>
-    <string name="DHIS_DEFAULT_SERVER" translatable="false">https://sandbox.cnm-mis.org/</string>
+    <string name="default_login_url" translatable="false">https://sandbox.cnm-mis.org/</string>
     <string name="work_in_progress" translatable="false">Work in progress</string>
 
 

--- a/app/src/cnm/res/xml/pref_general.xml
+++ b/app/src/cnm/res/xml/pref_general.xml
@@ -43,7 +43,7 @@
         android:key="@string/pref_cat_server"
         android:title="@string/server">
         <EditTextPreference
-            android:defaultValue="@string/DHIS_DEFAULT_SERVER"
+            android:defaultValue="@string/default_login_url"
             android:inputType="textUri"
             android:key="@string/dhis_url"
             android:maxLines="1"

--- a/app/src/cnm/res/xml/pref_general.xml
+++ b/app/src/cnm/res/xml/pref_general.xml
@@ -45,7 +45,7 @@
         <EditTextPreference
             android:defaultValue="@string/default_login_url"
             android:inputType="textUri"
-            android:key="@string/dhis_url"
+            android:key="@string/server_url_preference_key"
             android:maxLines="1"
             android:selectAllOnFocus="true"
             android:singleLine="true"

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/database/utils/PreferencesEReferral.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/database/utils/PreferencesEReferral.java
@@ -17,7 +17,7 @@ public class PreferencesEReferral {
         Context context = PreferencesState.getInstance().getContext();
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(
                 context);
-        String url = sharedPreferences.getString(context.getString(R.string.dhis_url), null);
+        String url = sharedPreferences.getString(context.getString(R.string.server_url_preference_key), null);
 
         String username = sharedPreferences.getString(
                 context.getString(R.string.logged_user_username), null);

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationDataSourceFactory.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationDataSourceFactory.java
@@ -11,7 +11,7 @@ public class MetadataConfigurationDataSourceFactory {
     public static IMetadataConfigurationDataSource getMetadataConfigurationDataSource(
             BasicAuthInterceptor basicAuthInterceptor)
             throws Exception {
-        return new MetadataConfigurationApiClient(PreferencesState.getInstance().getDhisURL(),
+        return new MetadataConfigurationApiClient(PreferencesState.getInstance().getServerURL(),
                 basicAuthInterceptor);
     }
 }

--- a/app/src/ereferrals/res/values/donottranslate.xml
+++ b/app/src/ereferrals/res/values/donottranslate.xml
@@ -3,7 +3,7 @@
     <string name="rdtPositive" translatable="false">1</string>
     <string name="rdtNegative" translatable="false">0</string>
     <string name="rdtNotTested" translatable="false">Not Tested</string>
-    <string name="DHIS_DEFAULT_SERVER" translatable="false">https://data.psi-mis.org</string>
+    <string name="default_login_url" translatable="false">https://apps.psi-mis.org</string>
     <string name="url_server_demo_login" translatable="false">demo.server</string>
     <string name="monitor_row_title" translatable="false"><![CDATA[%1$s]]></string>
     <string name="monitor_row_title_space" translatable="false"><![CDATA[&nbsp;&nbsp;]]></string>

--- a/app/src/ereferrals/res/values/donottranslate.xml
+++ b/app/src/ereferrals/res/values/donottranslate.xml
@@ -3,6 +3,7 @@
     <string name="rdtPositive" translatable="false">1</string>
     <string name="rdtNegative" translatable="false">0</string>
     <string name="rdtNotTested" translatable="false">Not Tested</string>
+    <string name="server_url_preference_key" translatable="false">@string/web_service_url</string>
     <string name="default_login_url" translatable="false">https://apps.psi-mis.org</string>
     <string name="url_server_demo_login" translatable="false">demo.server</string>
     <string name="monitor_row_title" translatable="false"><![CDATA[%1$s]]></string>

--- a/app/src/ereferrals/res/xml/pref_general.xml
+++ b/app/src/ereferrals/res/xml/pref_general.xml
@@ -43,7 +43,7 @@
         android:key="@string/pref_cat_server"
         android:title="@string/server">
         <EditTextPreference
-            android:defaultValue="@string/DHIS_DEFAULT_SERVER"
+            android:defaultValue="@string/default_login_url"
             android:inputType="textUri"
             android:key="@string/dhis_url"
             android:maxLines="1"

--- a/app/src/ereferrals/res/xml/pref_general.xml
+++ b/app/src/ereferrals/res/xml/pref_general.xml
@@ -42,14 +42,6 @@
     <PreferenceCategory
         android:key="@string/pref_cat_server"
         android:title="@string/server">
-        <EditTextPreference
-            android:defaultValue="@string/default_login_url"
-            android:inputType="textUri"
-            android:key="@string/server_url_preference_key"
-            android:maxLines="1"
-            android:selectAllOnFocus="true"
-            android:singleLine="true"
-            android:title="@string/server_name" />
 
         <org.eyeseetea.malariacare.views.AutoCompleteEditTextPreference
             android:defaultValue=""

--- a/app/src/ereferrals/res/xml/pref_general.xml
+++ b/app/src/ereferrals/res/xml/pref_general.xml
@@ -45,7 +45,7 @@
         <EditTextPreference
             android:defaultValue="@string/default_login_url"
             android:inputType="textUri"
-            android:key="@string/dhis_url"
+            android:key="@string/server_url_preference_key"
             android:maxLines="1"
             android:selectAllOnFocus="true"
             android:singleLine="true"

--- a/app/src/laos/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
+++ b/app/src/laos/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
@@ -40,6 +40,16 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
 
     @Override
     public void setupPreferencesScreen(PreferenceScreen preferenceScreen) {
+        Preference  serverUrlPreference = (Preference) findPreference(
+                getApplicationContext().getResources().getString(R.string.dhis_url));
+        serverUrlPreference.setOnPreferenceClickListener(
+                mSettingsActivityStrategy.getOnPreferenceClickListener());
+    }
+
+    @Override
+    public void addExtraPreferences() {
+        settingsActivity.bindPreferenceSummaryToValue(
+                settingsActivity.findPreference(settingsActivity.getString(R.string.dhis_url)));
     }
 
     @Override

--- a/app/src/laos/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
+++ b/app/src/laos/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
@@ -40,16 +40,16 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
 
     @Override
     public void setupPreferencesScreen(PreferenceScreen preferenceScreen) {
-        Preference  serverUrlPreference = (Preference) findPreference(
-                getApplicationContext().getResources().getString(R.string.dhis_url));
+        Preference serverUrlPreference = (Preference) preferenceScreen.findPreference(
+                preferenceScreen.getContext().getResources().getString(R.string.server_url_preference_key));
         serverUrlPreference.setOnPreferenceClickListener(
-                mSettingsActivityStrategy.getOnPreferenceClickListener());
+                getOnPreferenceClickListener());
     }
 
     @Override
     public void addExtraPreferences() {
         settingsActivity.bindPreferenceSummaryToValue(
-                settingsActivity.findPreference(settingsActivity.getString(R.string.dhis_url)));
+                settingsActivity.findPreference(settingsActivity.getString(R.string.server_url_preference_key)));
     }
 
     @Override

--- a/app/src/laos/res/values/donottranslate.xml
+++ b/app/src/laos/res/values/donottranslate.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <item name="dhis_url" translatable="false" type="string">dhis_url</item>
     <string name="ACT_x_6" translatable="false">ACT6x1</string>
     <string name="ACT_x_12" translatable="false">ACT6x2</string>
     <string name="ACT_x_18" translatable="false">ACT6x3</string>
@@ -7,7 +8,7 @@
     <string name="rdtPositive" translatable="false">1</string>
     <string name="rdtNegative" translatable="false">0</string>
     <string name="rdtNotTested" translatable="false">Not Tested</string>
-    <string name="DHIS_DEFAULT_SERVER" translatable="false">https://data.psi-mis.org</string>
+    <string name="default_login_url" translatable="false">https://data.psi-mis.org</string>
     <string name="work_in_progress" translatable="false">Work in progress</string>
 
 

--- a/app/src/laos/res/xml/pref_general.xml
+++ b/app/src/laos/res/xml/pref_general.xml
@@ -43,7 +43,7 @@
         android:key="@string/pref_cat_server"
         android:title="@string/server">
         <EditTextPreference
-            android:defaultValue="@string/DHIS_DEFAULT_SERVER"
+            android:defaultValue="@string/default_login_url"
             android:inputType="textUri"
             android:key="@string/dhis_url"
             android:maxLines="1"

--- a/app/src/laos/res/xml/pref_general.xml
+++ b/app/src/laos/res/xml/pref_general.xml
@@ -45,7 +45,7 @@
         <EditTextPreference
             android:defaultValue="@string/default_login_url"
             android:inputType="textUri"
-            android:key="@string/dhis_url"
+            android:key="@string/server_url_preference_key"
             android:maxLines="1"
             android:selectAllOnFocus="true"
             android:singleLine="true"

--- a/app/src/main/java/org/eyeseetea/malariacare/SettingsActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/SettingsActivity.java
@@ -97,7 +97,6 @@ public class SettingsActivity extends PreferenceActivity implements
             };
     public SettingsActivityStrategy mSettingsActivityStrategy = new SettingsActivityStrategy(this);
     public AutoCompleteEditTextPreference autoCompleteEditTextPreference;
-    public Preference serverUrlPreference;
 
     /**
      * Binds a preference's summary to its value. More specifically, when the
@@ -179,8 +178,6 @@ public class SettingsActivity extends PreferenceActivity implements
         bindPreferenceSummaryToValue(
                 findPreference(getApplicationContext().getString(R.string.font_sizes)));
         bindPreferenceSummaryToValue(
-                findPreference(getApplicationContext().getString(R.string.dhis_url)));
-        bindPreferenceSummaryToValue(
                 findPreference(getApplicationContext().getString(R.string.org_unit)));
 
         autoCompleteEditTextPreference = (AutoCompleteEditTextPreference) findPreference(
@@ -190,10 +187,6 @@ public class SettingsActivity extends PreferenceActivity implements
         autoCompleteEditTextPreference.pullOrgUnits();
 
         autoCompleteEditTextPreference.setContext(this);
-        serverUrlPreference = (Preference) findPreference(
-                getApplicationContext().getResources().getString(R.string.dhis_url));
-        serverUrlPreference.setOnPreferenceClickListener(
-                mSettingsActivityStrategy.getOnPreferenceClickListener());
 
         mSettingsActivityStrategy.setupPreferencesScreen(getPreferenceScreen());
 
@@ -207,9 +200,6 @@ public class SettingsActivity extends PreferenceActivity implements
                     this.getResources().getString(R.string.customize_fonts)));
         }
         if (mSettingsActivityStrategy.getOnPreferenceChangeListener() != null) {
-            serverUrlPreference.setOnPreferenceChangeListener(
-                    mSettingsActivityStrategy.getOnPreferenceChangeListener());
-
             autoCompleteEditTextPreference.setOnPreferenceChangeListener(
                     mSettingsActivityStrategy.getOnPreferenceChangeListener());
         }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/AuthenticationLocalDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/AuthenticationLocalDataSource.java
@@ -60,7 +60,7 @@ public class AuthenticationLocalDataSource implements IAuthenticationDataSource 
 
 
     private void saveCredentials(Credentials credentials) {
-        PreferencesState.getInstance().saveStringPreference(R.string.dhis_url,
+        PreferencesState.getInstance().saveStringPreference(R.string.server_url_preference_key,
                 credentials.getServerURL());
         PreferencesState.getInstance().saveStringPreference(R.string.dhis_user,
                 credentials.getUsername());
@@ -71,8 +71,8 @@ public class AuthenticationLocalDataSource implements IAuthenticationDataSource 
 
 
     public void clearCredentials() {
-        PreferencesState.getInstance().saveStringPreference(R.string.dhis_url,
-                mContext.getString(R.string.DHIS_DEFAULT_SERVER));
+        PreferencesState.getInstance().saveStringPreference(R.string.server_url_preference_key,
+                mContext.getString(R.string.default_login_url));
         PreferencesState.getInstance().saveStringPreference(R.string.dhis_user, "");
         PreferencesState.getInstance().saveStringPreference(R.string.dhis_password, "");
         PreferencesState.getInstance().reloadPreferences();

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/utils/PreferencesState.java
@@ -76,7 +76,7 @@ public class PreferencesState {
     /**
      * Specified DHIS2 Server
      */
-    private String dhisURL;
+    private String serverURL;
 
     private boolean userAccept;
 
@@ -97,7 +97,7 @@ public class PreferencesState {
         Context context = PreferencesState.getInstance().getContext();
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(
                 context);
-        String url = sharedPreferences.getString(context.getString(R.string.dhis_url), "");
+        String url = sharedPreferences.getString(context.getString(R.string.server_url_preference_key), "");
 
         String username = sharedPreferences.getString(context.getString(R.string.dhis_user), "");
         String password = sharedPreferences.getString(context.getString(R.string.dhis_password),
@@ -139,11 +139,11 @@ public class PreferencesState {
         fontStyle = initFontStyle();
         showNumDen = initShowNumDen();
         orgUnit = initOrgUnit();
-        dhisURL = initDhisURL();
+        serverURL = initServerURL();
         languageCode = initLanguageCode();
         Log.d(TAG, "reloadPreferences: "
                 + " orgUnit:" + orgUnit
-                + " |dhisURL:" + dhisURL
+                + " |serverURL:" + serverURL
                 + " |fontStyle:" + fontStyle.getTitle()
                 + " | showNumDen:" + showNumDen);
     }
@@ -180,11 +180,11 @@ public class PreferencesState {
     /**
      * Returns 'DhisURL' from sharedPreferences
      */
-    private String initDhisURL() {
+    private String initServerURL() {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(
                 instance.getContext());
-        return sharedPreferences.getString(instance.getContext().getString(R.string.dhis_url),
-                instance.getContext().getString(R.string.DHIS_DEFAULT_SERVER));
+        return sharedPreferences.getString(instance.getContext().getString(R.string.server_url_preference_key),
+                instance.getContext().getString(R.string.default_login_url));
     }
 
     public boolean isCustomizeFontActive() {
@@ -272,12 +272,12 @@ public class PreferencesState {
 
         return new Program(code,id);
     }
-    public String getDhisURL() {
-        return dhisURL;
+    public String getServerURL() {
+        return serverURL;
     }
 
-    public void setDhisURL(String dhisURL) {
-        this.dhisURL = dhisURL;
+    public void setServerURL(String serverURL) {
+        this.serverURL = serverURL;
     }
 
     public String getLanguageCode() {

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/LoadUserAndCredentialsUseCase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/LoadUserAndCredentialsUseCase.java
@@ -30,7 +30,7 @@ public class LoadUserAndCredentialsUseCase {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(
                 mContext);
 
-        String serverURL = sharedPreferences.getString(mContext.getString(R.string.dhis_url), "");
+        String serverURL = sharedPreferences.getString(mContext.getString(R.string.server_url_preference_key), "");
         String username = sharedPreferences.getString(mContext.getString(R.string.dhis_user), "");
         String password = sharedPreferences.getString(mContext.getString(R.string.dhis_password),
                 "");

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/listeners/LoginRequiredOnPreferenceClickListener.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/listeners/LoginRequiredOnPreferenceClickListener.java
@@ -28,7 +28,7 @@ public class LoginRequiredOnPreferenceClickListener implements
     @Override
     public boolean onPreferenceClick(final Preference preference) {
         if (!settingsActivity.getIntent().getBooleanExtra(SettingsActivity.IS_LOGIN_DONE, false)
-                || preference.getKey().equals(PreferencesState.getInstance().getContext().getString(R.string.dhis_url))) {
+                || preference.getKey().equals(PreferencesState.getInstance().getContext().getString(R.string.server_url_preference_key))) {
             //if is not logged the pull of data is required.
             PreferencesState.getInstance().setMetaDataDownload(true);
             //only in laos y cambodiates

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/listeners/PullRequiredOnPreferenceChangeListener.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/listeners/PullRequiredOnPreferenceChangeListener.java
@@ -33,6 +33,6 @@ public class PullRequiredOnPreferenceChangeListener implements
 
     private boolean preferenceIsDhisUrl(Preference preference) {
         return preference.getKey() == preference.getContext().getResources().getString(
-                R.string.dhis_url);
+                R.string.server_url_preference_key);
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/network/PushClient.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/network/PushClient.java
@@ -81,7 +81,7 @@ public class PushClient {
     /**
      * Current server url
      */
-    private static String SERVER_URL = "https://www.psi-mis.org";
+    private static String SERVER_URL;
     SurveyDB mSurveyDB;
     Activity activity;
     Context applicationContext;

--- a/app/src/main/java/org/eyeseetea/malariacare/network/PushClient.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/network/PushClient.java
@@ -111,7 +111,7 @@ public class PushClient {
      */
     public void getPreferenceValues() {
         PreferencesState.getInstance().reloadPreferences();
-        String url = PreferencesState.getInstance().getDhisURL();
+        String url = PreferencesState.getInstance().getServerURL();
         if (url != null || !("".equals(url))) {
             DHIS_SERVER = url;
         }

--- a/app/src/main/java/org/eyeseetea/malariacare/network/PushClient.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/network/PushClient.java
@@ -81,7 +81,7 @@ public class PushClient {
     /**
      * Current server url
      */
-    private static String DHIS_SERVER = "https://www.psi-mis.org";
+    private static String SERVER_URL = "https://www.psi-mis.org";
     SurveyDB mSurveyDB;
     Activity activity;
     Context applicationContext;
@@ -113,7 +113,7 @@ public class PushClient {
         PreferencesState.getInstance().reloadPreferences();
         String url = PreferencesState.getInstance().getServerURL();
         if (url != null || !("".equals(url))) {
-            DHIS_SERVER = url;
+            SERVER_URL = url;
         }
     }
 
@@ -163,7 +163,7 @@ public class PushClient {
     private JSONObject pushData(JSONObject data) throws ApiCallException {
         Response response = null;
 
-        final String DHIS_URL = getDhisURL();
+        final String DHIS_URL = getServerURL();
 
         BasicAuthenticator basicAuthenticator = new BasicAuthenticator();
 
@@ -327,8 +327,8 @@ public class PushClient {
     /**
      * Returns the URL that points to the DHIS server API according to preferences.
      */
-    private String getDhisURL() {
-        String url = DHIS_SERVER + DHIS_PUSH_API;
+    private String getServerURL() {
+        String url = SERVER_URL + DHIS_PUSH_API;
         return ServerApiUtils.encodeBlanks(url);
     }
 

--- a/app/src/main/java/org/eyeseetea/malariacare/network/ServerAPIController.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/network/ServerAPIController.java
@@ -168,7 +168,7 @@ public class ServerAPIController {
      * Returns current serverUrl
      */
     public static String getServerUrl() {
-        return PreferencesState.getInstance().getDhisURL();
+        return PreferencesState.getInstance().getServerURL();
     }
 
     /**
@@ -453,7 +453,7 @@ public class ServerAPIController {
      */
      public static Program getOrganisationUnitGroupByOrganisationUnit(@NotNull String orgUnitCode) throws ApiCallException {
         //Version is required to choose which field to match
-        String url = PreferencesState.getInstance().getDhisURL();
+        String url = PreferencesState.getInstance().getServerURL();
 
         String urlOrgUnitData = getOrgUnitGroupDataUrl(url, orgUnitCode);
         Response response = ServerApiCallExecution.executeCall(null, urlOrgUnitData, "GET");
@@ -505,7 +505,7 @@ public class ServerAPIController {
         String lastMessage = loggedUserDB.getAnnouncement();
         String uid = loggedUserDB.getUid();
         String url =
-                PreferencesState.getInstance().getDhisURL() + "/api/" + TAG_USER + String.format(
+                PreferencesState.getInstance().getServerURL() + "/api/" + TAG_USER + String.format(
                         QUERY_USER_ATTRIBUTES, uid);
         url = ServerApiUtils.encodeBlanks(url);
         Response response = ServerApiCallExecution.executeCall(null, url, "GET");
@@ -546,7 +546,7 @@ public class ServerAPIController {
 
         //Lets for a last event with that orgunit/program
         String url =
-                PreferencesState.getInstance().getDhisURL() + "/api/" + TAG_USER + String.format(
+                PreferencesState.getInstance().getServerURL() + "/api/" + TAG_USER + String.format(
                         QUERY_USER_ATTRIBUTES, userUid);
 
         url = ServerApiUtils.encodeBlanks(url);
@@ -577,7 +577,7 @@ public class ServerAPIController {
             String code)
             throws ApiCallException {
         //Version is required to choose which field to match
-        String serverVersion = getServerVersion(PreferencesState.getInstance().getDhisURL());
+        String serverVersion = getServerVersion(PreferencesState.getInstance().getServerURL());
 
         //No version -> No data
         if (serverVersion == null) {
@@ -770,7 +770,7 @@ public class ServerAPIController {
     }
 
     static String getOrganisationUnitsCredentialsUrl(String code) {
-        String url = PreferencesState.getInstance().getDhisURL()
+        String url = PreferencesState.getInstance().getServerURL()
                 + "/api/organisationUnits.json?filter=code:eq:%s&fields=id,name,description,code,"
                 + "ancestors[id,"
                 + "code,level],attributeValues[value,attribute[code]";
@@ -798,7 +798,7 @@ public class ServerAPIController {
 
     public static OrganisationUnit getOrgUnitByPhone(String imei)
             throws ApiCallException, ExistsMoreThanOneOrgUnitByPhoneException {
-        String url = PreferencesState.getInstance().getDhisURL()
+        String url = PreferencesState.getInstance().getServerURL()
                 + "/api/organisationUnits.json?filter=phoneNumber:like:%s&fields=id,name,"
                 + "description,"
                 + "code,"

--- a/app/src/main/java/org/eyeseetea/malariacare/network/SurveyChecker.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/network/SurveyChecker.java
@@ -65,7 +65,7 @@ public class SurveyChecker {
             Date maxDate) throws ApiCallException {
             Response response;
 
-            String DHIS_URL = PreferencesState.getInstance().getDhisURL();
+            String DHIS_URL = PreferencesState.getInstance().getServerURL();
             String startDate = EventExtended.format(minDate, EventExtended.AMERICAN_DATE_FORMAT);
             String endDate = EventExtended.format(
                     new Date(maxDate.getTime() + (8 * 24 * 60 * 60 * 1000)),

--- a/app/src/main/java/org/eyeseetea/malariacare/strategies/ASettingsActivityStrategy.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/strategies/ASettingsActivityStrategy.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 import android.preference.Preference;
 import android.preference.PreferenceScreen;
 
+import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.SettingsActivity;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.utils.Utils;
@@ -32,6 +33,8 @@ public abstract class ASettingsActivityStrategy {
 
     public abstract Preference.OnPreferenceChangeListener getOnPreferenceChangeListener();
 
+    public abstract void addExtraPreferences();
+
     public abstract void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key);
 
 
@@ -40,9 +43,6 @@ public abstract class ASettingsActivityStrategy {
     public abstract void onBackPressed();
 
     public abstract void onWindowFocusChanged(boolean hasFocus);
-
-    public void addExtraPreferences() {
-    }
 
     public void onDestroy() {
 

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -9,7 +9,6 @@
     <item name="pref_visual" translatable="false" type="string">pref_visual</item>
     <item name="customize_fonts" translatable="false" type="string">customize_fonts</item>
     <item name="font_sizes" translatable="false" type="string">font_sizes</item>
-    <item name="dhis_url" translatable="false" type="string">dhis_url</item>
     <item name="dhis_user" translatable="false" type="string">dhis_user</item>
     <item name="dhis_password" translatable="false" type="string">dhis_password</item>
     <item name="org_unit" translatable="false" type="string">org_unit</item>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="eyeseetea" translatable="false">EyeSeeTea LTD</string>
     <string name="empty_string" translatable="false"></string>
+    <string name="server_url_preference_key" translatable="false">@string/dhis_url</string>
     <string name="details">Details</string>
     <string name="lorem_ipsum" translatable="false">Lorem ipsum dolor sit amet</string>
 

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -43,7 +43,7 @@
         android:key="@string/pref_cat_server"
         android:title="@string/server">
         <EditTextPreference
-            android:defaultValue="@string/DHIS_DEFAULT_SERVER"
+            android:defaultValue="@string/default_login_url"
             android:inputType="textUri"
             android:key="@string/dhis_url"
             android:maxLines="1"

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -42,14 +42,6 @@
     <PreferenceCategory
         android:key="@string/pref_cat_server"
         android:title="@string/server">
-        <EditTextPreference
-            android:defaultValue="@string/default_login_url"
-            android:inputType="textUri"
-            android:key="@string/server_url_preference_key"
-            android:maxLines="1"
-            android:selectAllOnFocus="true"
-            android:singleLine="true"
-            android:title="@string/server_name" />
 
         <org.eyeseetea.malariacare.views.AutoCompleteEditTextPreference
             android:defaultValue=""

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -45,7 +45,7 @@
         <EditTextPreference
             android:defaultValue="@string/default_login_url"
             android:inputType="textUri"
-            android:key="@string/dhis_url"
+            android:key="@string/server_url_preference_key"
             android:maxLines="1"
             android:selectAllOnFocus="true"
             android:singleLine="true"

--- a/app/src/myanmar/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
+++ b/app/src/myanmar/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
@@ -38,6 +38,16 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
                         settingsActivity.getResources().getString(R.string.pref_cat_server));
         preferenceCategory.removePreference(preferenceScreen.findPreference(
                 settingsActivity.getResources().getString(R.string.org_unit)));
+        Preference  serverUrlPreference = (Preference) findPreference(
+                getApplicationContext().getResources().getString(R.string.dhis_url));
+        serverUrlPreference.setOnPreferenceClickListener(
+                mSettingsActivityStrategy.getOnPreferenceClickListener());
+    }
+
+    @Override
+    public void addExtraPreferences() {
+        settingsActivity.bindPreferenceSummaryToValue(
+                settingsActivity.findPreference(settingsActivity.getString(R.string.dhis_url)));
     }
 
     @Override

--- a/app/src/myanmar/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
+++ b/app/src/myanmar/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
@@ -38,16 +38,17 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
                         settingsActivity.getResources().getString(R.string.pref_cat_server));
         preferenceCategory.removePreference(preferenceScreen.findPreference(
                 settingsActivity.getResources().getString(R.string.org_unit)));
-        Preference  serverUrlPreference = (Preference) findPreference(
-                getApplicationContext().getResources().getString(R.string.dhis_url));
+
+        Preference serverUrlPreference = (Preference) preferenceScreen.findPreference(
+                preferenceScreen.getContext().getResources().getString(R.string.server_url_preference_key));
         serverUrlPreference.setOnPreferenceClickListener(
-                mSettingsActivityStrategy.getOnPreferenceClickListener());
+                getOnPreferenceClickListener());
     }
 
     @Override
     public void addExtraPreferences() {
         settingsActivity.bindPreferenceSummaryToValue(
-                settingsActivity.findPreference(settingsActivity.getString(R.string.dhis_url)));
+                settingsActivity.findPreference(settingsActivity.getString(R.string.server_url_preference_key)));
     }
 
     @Override

--- a/app/src/myanmar/res/values/donottranslate.xml
+++ b/app/src/myanmar/res/values/donottranslate.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <item name="dhis_url" translatable="false" type="string">dhis_url</item>
     <string name="rdtPositive" translatable="false">1</string>
     <string name="rdtNegative" translatable="false">0</string>
     <string name="rdtNotTested" translatable="false">Not Tested</string>
-    <string name="DHIS_DEFAULT_SERVER" translatable="false">https://dev.scpr-mm-mal.org</string>
+    <string name="default_login_url" translatable="false">https://dev.scpr-mm-mal.org</string>
     <string name="url_server_demo_login" translatable="false">demo.server</string>
     <string name="monitor_row_title" translatable="false"><![CDATA[%1$s]]></string>
     <string name="monitor_row_title_space" translatable="false"><![CDATA[&nbsp;&nbsp;]]></string>

--- a/app/src/myanmar/res/xml/pref_general.xml
+++ b/app/src/myanmar/res/xml/pref_general.xml
@@ -43,7 +43,7 @@
         android:key="@string/pref_cat_server"
         android:title="@string/server">
         <EditTextPreference
-            android:defaultValue="@string/DHIS_DEFAULT_SERVER"
+            android:defaultValue="@string/default_login_url"
             android:inputType="textUri"
             android:key="@string/dhis_url"
             android:maxLines="1"

--- a/app/src/myanmar/res/xml/pref_general.xml
+++ b/app/src/myanmar/res/xml/pref_general.xml
@@ -45,7 +45,7 @@
         <EditTextPreference
             android:defaultValue="@string/default_login_url"
             android:inputType="textUri"
-            android:key="@string/dhis_url"
+            android:key="@string/server_url_preference_key"
             android:maxLines="1"
             android:selectAllOnFocus="true"
             android:singleLine="true"


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2250  
* **Related pull-requests:** 

### :tophat: What is the goal?

 Remove DHIS2 server URL setting on ereferals.

 Change url in login to https://apps.psi-mis.org (but the login doesn't work with that url)

 Change login server settings from DHIS2 to Webservice

### :memo: How is it being implemented?


I create a string resource named "server_url_preference_key" to contains the server url preference. 
I remove all dhis_url method to ask for the server_url using the server_url_preference_key.
The server_url_preference_key in ereferrals contains the key of the webservice preference (web_service_url). In other variants  the string contains the dhis_url preference 
I change the dhis default value, and i rename the resource DHIS_DEFAULT_SERVER by default_login_url

I move the dhis_url setting from the main and ereferals to the other variants

### :boom: How can it be tested?

- [ ] **Use case 1:** Check the login server url is on webService url on settings.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
