### PR TITLE
Added new invalid network message on ereferals

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/LoginActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/LoginActivityStrategy.java
@@ -505,6 +505,21 @@ public class LoginActivityStrategy extends ALoginActivityStrategy {
         }
     }
 
+    @Override
+    public void onLoginNetworkError(Credentials credentials) {
+        loginActivity.hideProgressBar();
+        ICredentialsRepository credentialsLocalDataSource = new CredentialsLocalDataSource();
+        Credentials savedCredentials = credentialsLocalDataSource.getLastValidCredentials();
+        if(savedCredentials!=null && savedCredentials.getPassword()!=null &&
+                !savedCredentials.getPassword().equals(credentials.getPassword())
+                && savedCredentials.getUsername().equals(credentials.getUsername())
+                && savedCredentials.getServerURL().equals(credentials.getServerURL())){
+            loginActivity.showError(loginActivity.getString(R.string.login_invalid_credentials_and_network));
+        }else {
+            loginActivity.showError(loginActivity.getString(R.string.network_error));
+        }
+    }
+
     private void launchPull(boolean isDemo) {
         PullFilters pullFilters = new PullFilters();
         pullFilters.setStartDate(PreferencesState.getInstance().getDateStarDateLimitFilter());

--- a/app/src/ereferrals/res/values-ne/strings.xml
+++ b/app/src/ereferrals/res/values-ne/strings.xml
@@ -974,4 +974,5 @@
     <string name="settings_title_program_url_config">"प्रोग्राम विन्यास URL"</string>
     <string name="settings_title_program_username_config">"प्रोग्राम कन्फिगरेसन प्रयोगकर्ता नाम"</string>
     <string name="settings_title_program_password_config">"प्रोग्राम कन्फिगरेसन पासवर्ड"</string>
+    <string name="login_invalid_credentials_and_network">"प्रमाणपत्रहरू अमान्य छन् वा प्रमाणपत्रहरू अमान्य छन् र जडान उपलब्ध छैन"</string>
 </resources>

--- a/app/src/ereferrals/res/values-pt/strings.xml
+++ b/app/src/ereferrals/res/values-pt/strings.xml
@@ -969,4 +969,5 @@
     <string name="settings_title_program_url_config">"URL de configuração do programa"</string>
     <string name="settings_title_program_username_config">"Nome de usuário da configuração do programa"</string>
     <string name="settings_title_program_password_config">"Senha de configuração do programa"</string>
+    <string name="login_invalid_credentials_and_network">"As credenciais são inválidas ou as credenciais são inválidas e a conexão não está disponível"</string>
 </resources>

--- a/app/src/ereferrals/res/values-sw/strings.xml
+++ b/app/src/ereferrals/res/values-sw/strings.xml
@@ -1028,4 +1028,5 @@ Ameahidi kuhudhuria"</string>
 <string name="settings_title_program_url_config">"Programkonfigurationsadress"</string>
 <string name="settings_title_program_username_config">"Programkonfigurations användarnamn"</string>
 <string name="settings_title_program_password_config">"Programkonfigurationslösenord"</string>
+<string name="login_invalid_credentials_and_network">"Inloggningsuppgifterna är ogiltiga eller referensuppgifterna är ogiltiga och connexion är inte tillgängligt"</string>
 </resources>

--- a/app/src/ereferrals/res/values/strings.xml
+++ b/app/src/ereferrals/res/values/strings.xml
@@ -868,6 +868,7 @@
 <string name="date_format_forward_slash">"yyyy/mm/dd"</string>
 <string name="network_error">"There is a problem with the network, please try again later."</string>
 <string name="login_invalid_credentials">"Invalid credentials"</string>
+<string name="login_invalid_credentials_and_network">"The credentials are invalid or the credentials are invalid and connexion is not available"</string>
 <string name="login_unexpected_error">"An error has occurred, please try again later"</string>
 <string name="login_invalid_server_url">"Invalid Server URL"</string>
 <string name="error_conflict_message">"The event with UID: %1$s. was uploaded with conflict in the data element UID: %2$s with the message: %3$s. Please contact the administrator."</string>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2286 
* **Related pull-requests:**

### :tophat: What is the goal?

Add a error message if the user try to login with invalid credentials without network

### :memo: How is it being implemented?

I check the login network credentials error with the last saved credentials to decide the error network message.


### :boom: How can it be tested?

Note: remove the android security pattern is required to test this feature.

 **Use case 1:** Login, block the android screen, and disconect from network... unblock. If you put a invalid password you will see a toast: "The credentials are invalid or the credentials are invalid and connexion is not available", else a network error.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-