### PR TITLE
Feature add slow load of village question

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/DynamicTabAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/DynamicTabAdapter.java
@@ -86,6 +86,7 @@ import org.eyeseetea.malariacare.views.question.IMultiQuestionView;
 import org.eyeseetea.malariacare.views.question.INavigationQuestionView;
 import org.eyeseetea.malariacare.views.question.IQuestionView;
 import org.eyeseetea.malariacare.views.question.multiquestion.DatePickerQuestionView;
+import org.eyeseetea.malariacare.views.question.multiquestion.OuTreeMultiQuestionView;
 import org.eyeseetea.malariacare.views.question.multiquestion.YearSelectorQuestionView;
 import org.eyeseetea.malariacare.views.question.singlequestion.ImageRadioButtonSingleQuestionView;
 import org.eyeseetea.malariacare.views.question.singlequestion.NumberSingleQuestionView;
@@ -618,7 +619,7 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
                         screenQuestionDB.getInternationalizedPath());
             }
             mDynamicTabAdapterStrategy.renderParticularSurvey(screenQuestionDB, surveyDB, questionView);
-            if(questionView instanceof CommonQuestionView){
+            if(questionView instanceof CommonQuestionView && requireQuestionOptionValidations(questionView)){
                 ((CommonQuestionView) questionView).setQuestion(QuestionMapper.mapFromDbToDomain(screenQuestionDB));
             }
             if (questionView instanceof AOptionQuestionView) {
@@ -685,6 +686,11 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
                 ((CommonQuestionView) questionView).initContainers(tableRow, tableLayout);
             }
         }
+    }
+
+    //The OuTreeMultiQuestionView question don't required extra validations.
+    private boolean requireQuestionOptionValidations(IQuestionView questionView) {
+        return !(questionView instanceof OuTreeMultiQuestionView);
     }
 
     @Nullable


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2309
* **Related pull-requests:** 

### :tophat: What is the goal?

HC Program: Very slow transition from Test Result RDT question to Village of Residence question
Make it faster again.

### :memo: How is it being implemented?

We added some validations in ereferrals. The new validations requires the mapping of QuestionDB to Question.
In the case of Org unit tree quesiton the validations aren't required, and the map from questionDb to Question is so slow because the question has about 10.000 options and option attributes.

I added a check to know if the question requires that validation to avoid that unnecesary mapping in the case of the org unit tree question.


### :boom: How can it be tested?

- [ ] **Use case 1:** The load of village question should be shown in less than 5 seconds.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

