### PR TITLE
Solved bug with autoconfigure deleting the server url

### DIFF
--- a/app/src/cnm/java/org/eyeseetea/malariacare/data/database/datasources/strategies/AuthenticationLocalDataSourceStrategy.java
+++ b/app/src/cnm/java/org/eyeseetea/malariacare/data/database/datasources/strategies/AuthenticationLocalDataSourceStrategy.java
@@ -1,8 +1,12 @@
 package org.eyeseetea.malariacare.data.database.datasources.strategies;
 
+import android.content.Context;
+
+import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.data.IDataSourceCallback;
 import org.eyeseetea.malariacare.data.database.datasources.AuthenticationLocalDataSource;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesCNM;
+import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 
 
 public class AuthenticationLocalDataSourceStrategy extends AAuthenticationLocalDataSourceStrategy {
@@ -15,5 +19,12 @@ public class AuthenticationLocalDataSourceStrategy extends AAuthenticationLocalD
     public void logout(IDataSourceCallback<Void> callback) {
         super.logout(callback);
         PreferencesCNM.setMetadataDownloaded(false);
+    }
+
+    @Override
+    public void clearCredentials(Context context) {
+        PreferencesState.getInstance().saveStringPreference(R.string.dhis_user, "");
+        PreferencesState.getInstance().saveStringPreference(R.string.dhis_password, "");
+        PreferencesState.getInstance().reloadPreferences();
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/AuthenticationLocalDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/AuthenticationLocalDataSource.java
@@ -70,11 +70,7 @@ public class AuthenticationLocalDataSource implements IAuthenticationDataSource 
 
 
     public void clearCredentials() {
-        PreferencesState.getInstance().saveStringPreference(R.string.server_url_key,
-                mAuthenticationLocalDataSourceStrategy.getServerDefaultUrl(mContext));
-        PreferencesState.getInstance().saveStringPreference(R.string.dhis_user, "");
-        PreferencesState.getInstance().saveStringPreference(R.string.dhis_password, "");
-        PreferencesState.getInstance().reloadPreferences();
+        mAuthenticationLocalDataSourceStrategy.clearCredentials(mContext);
     }
 
 

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/strategies/AAuthenticationLocalDataSourceStrategy.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/strategies/AAuthenticationLocalDataSourceStrategy.java
@@ -67,4 +67,12 @@ public abstract class AAuthenticationLocalDataSourceStrategy {
     public String getServerDefaultUrl(Context mContext) {
         return mContext.getString(R.string.DEFAULT_SERVER_URL);
     }
+
+    public void clearCredentials(Context context) {
+        PreferencesState.getInstance().saveStringPreference(R.string.server_url_key,
+                getServerDefaultUrl(context));
+        PreferencesState.getInstance().saveStringPreference(R.string.dhis_user, "");
+        PreferencesState.getInstance().saveStringPreference(R.string.dhis_password, "");
+        PreferencesState.getInstance().reloadPreferences();
+    }
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close  #2313 
* **Related pull-requests:** 

### :tophat: What is the goal?

Solved bug with autoconfigure deleting the server url.

### :memo: How is it being implemented?

Adding a method clearCedential in AAuthenticationLocalDataSourceStrategy to clear credentials and in AuthenticationLocalDataSourceStrategy from cnm variant implement this method not deleting the server url. Then call this method when clear credentials in AuthenticationLocalDataSource.

### :boom: How can it be tested?

- [ ] **Use case 1:**Add the ime of your phone to an orgunit to auto configure. Open the app change the server url and then click on autoconfigure and test that works correctly.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

