### PR TITLE
Feature refactor question entity

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/WSPullController.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/WSPullController.java
@@ -102,7 +102,8 @@ public class WSPullController implements IPullController {
                 IMetadataConfigurationDataSource metadataConfigurationDataSource =
                         metadataConfigurationDataSourceFactory.getMetadataConfigurationDataSource();
                 importer = new MetadataConfigurationDBImporter(
-                        metadataConfigurationDataSource, ConverterFactory.getQuestionConverter()
+                        metadataConfigurationDataSource, ConverterFactory.getQuestionConverter(),
+                        ConverterFactory.getOptionConverter()
                 );
 
                 IProgramRepository programRepository = new ProgramRepository();

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/WSPullController.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/WSPullController.java
@@ -14,9 +14,9 @@ import org.eyeseetea.malariacare.data.database.model.ProgramDB;
 import org.eyeseetea.malariacare.data.database.utils.PopulateDBStrategy;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.data.database.utils.populatedb.PopulateDB;
-import org.eyeseetea.malariacare.data.remote.IMetadataConfigurationDataSource;
 import org.eyeseetea.malariacare.data.repositories.ProgramRepository;
 import org.eyeseetea.malariacare.data.sync.factory.ConverterFactory;
+import org.eyeseetea.malariacare.data.sync.importer.metadata.configuration.IMetadataConfigurationDataSource;
 import org.eyeseetea.malariacare.data.sync.importer.metadata.configuration
         .MetadataConfigurationDBImporter;
 import org.eyeseetea.malariacare.data.sync.importer.metadata.configuration

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/IMetadataConfigurationDataSource.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/IMetadataConfigurationDataSource.java
@@ -1,7 +1,5 @@
-package org.eyeseetea.malariacare.data.remote;
+package org.eyeseetea.malariacare.data.sync.importer.metadata.configuration;
 
-
-import org.eyeseetea.malariacare.data.sync.importer.metadata.configuration.Metadata;
 import org.eyeseetea.malariacare.domain.entity.Configuration;
 
 import java.util.List;

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/Metadata.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/Metadata.java
@@ -1,0 +1,36 @@
+package org.eyeseetea.malariacare.data.sync.importer.metadata.configuration;
+
+import org.eyeseetea.malariacare.domain.entity.Option;
+import org.eyeseetea.malariacare.domain.entity.Question;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class Metadata {
+    List<Question> questions;
+    HashMap<String, List<Option>> options;
+
+    public Metadata() {
+        questions = new ArrayList<>();
+        options = new HashMap<>();
+    }
+
+    public void addQuestion(Question question, List<Option> questionOptions){
+        questions.add(question);
+        options.put(question.getCode(), questionOptions);
+
+    }
+
+    public List<Question> getQuestions() {
+        return questions;
+    }
+
+    public HashMap<String, List<Option>> getOptions() {
+        return options;
+    }
+
+    public List<Option> getOptionsByQuestion(String code){
+        return options.get(code);
+    }
+}

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationApiClient.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationApiClient.java
@@ -747,7 +747,7 @@ public class MetadataConfigurationApiClient implements IMetadataConfigurationDat
         private Option.Attribute getDefaultAttribute() {
             return Option.Attribute.newBuilder()
                     .id(1)
-                    .backgroundColour("#FFFFFF")
+                    .backgroundColour("FFFFFF")
                     .horizontalAlignment(Option.Attribute.HorizontalAlignment.NONE)
                     .verticalAlignment(Option.Attribute.VerticalAlignment.NONE)
                     .textSize(20).build();

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationApiClient.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationApiClient.java
@@ -56,7 +56,6 @@ import static org.eyeseetea.malariacare.domain.entity.Question.Visibility.VISIBL
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import org.eyeseetea.malariacare.data.remote.IMetadataConfigurationDataSource;
 import org.eyeseetea.malariacare.data.sync.importer.metadata.configuration.converter
         .PhoneFormatConvertToDomainVisitor;
 import org.eyeseetea.malariacare.data.sync.importer.metadata.configuration.model

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationApiClient.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationApiClient.java
@@ -102,7 +102,7 @@ public class MetadataConfigurationApiClient implements IMetadataConfigurationDat
     }
 
     @Override
-    public List<Question> getQuestionsByCountryCode(String countryCode) throws Exception {
+    public Metadata getQuestionsByCountryCode(String countryCode) throws Exception {
 
         MetadataConfigurationConverterApiModelToDomain
                 converter = new MetadataConfigurationConverterApiModelToDomain();
@@ -345,31 +345,34 @@ public class MetadataConfigurationApiClient implements IMetadataConfigurationDat
 
 
         @NonNull
-        private List<Question> convertToDomainQuestionsFrom(
+        private Metadata convertToDomainQuestionsFrom(
                 @NonNull List<MetadataConfigurationsApi.Question> apiQuestions) {
 
             List<Question> domainQuestions = new ArrayList<>();
+            Metadata metadata = new Metadata();
 
             boolean isImportantQuestionSelected = false;
             for (int questionIndex = 0; questionIndex < apiQuestions.size(); questionIndex++) {
-
                 MetadataConfigurationsApi.Question apiQuestion = apiQuestions.get(questionIndex);
 
                 Question domainQuestion = convertToDomainQuestionFrom(apiQuestion, questionIndex);
 
                 domainQuestions.add(domainQuestion);
+
                 mapDomainQuestionsByCode.put(domainQuestion.getCode(), domainQuestion);
 
                 if(!isImportantQuestionSelected) {
                     isImportantQuestionSelected = isImportantQuestion(domainQuestion);
                 }
+
+                metadata.addQuestion(domainQuestion, convertToDomainOptionsFrom(apiQuestion.options, apiQuestion));
             }
 
             setImportantDomainQuestion(domainQuestions, isImportantQuestionSelected);
 
             assignRulesToQuestions();
 
-            return domainQuestions;
+            return metadata;
         }
 
         private void setImportantDomainQuestion(List<Question> domainQuestions,
@@ -554,7 +557,6 @@ public class MetadataConfigurationApiClient implements IMetadataConfigurationDat
             domainOption.setRules(domainRules);
         }
 
-
         @NonNull
         private Question convertToDomainQuestionFrom(
                 @NonNull MetadataConfigurationsApi.Question apiQuestion, int index) {
@@ -567,7 +569,6 @@ public class MetadataConfigurationApiClient implements IMetadataConfigurationDat
                     .index(index)
                     .type(convertToDomainQuestionTypeFrom(apiQuestion.output))
                     .visibility(getVisibilityFrom(apiQuestion))
-                    .options(convertToDomainOptionsFrom(apiQuestion.options, apiQuestion))
                     .compulsory(apiQuestion.compulsory)
                     .rules(convertToDomainRules(apiQuestion.rules))
                     .regExp(apiQuestion.validationRegex)

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationDBImporter.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationDBImporter.java
@@ -3,6 +3,8 @@ package org.eyeseetea.malariacare.data.sync.importer.metadata.configuration;
 
 import android.support.annotation.NonNull;
 
+import com.raizlabs.android.dbflow.annotation.NotNull;
+
 import org.eyeseetea.malariacare.data.database.converts.CountryVersionConvertFromDomainVisitor;
 import org.eyeseetea.malariacare.data.database.model.AnswerDB;
 import org.eyeseetea.malariacare.data.database.model.CountryVersionDB;
@@ -21,6 +23,7 @@ import org.eyeseetea.malariacare.data.database.model.TabDB;
 import org.eyeseetea.malariacare.data.remote.IMetadataConfigurationDataSource;
 import org.eyeseetea.malariacare.data.sync.importer.IConvertDomainDBVisitor;
 import org.eyeseetea.malariacare.domain.entity.Configuration;
+import org.eyeseetea.malariacare.domain.entity.Option;
 import org.eyeseetea.malariacare.domain.entity.Program;
 import org.eyeseetea.malariacare.domain.entity.Question;
 import org.eyeseetea.malariacare.domain.exception.WarningException;
@@ -34,6 +37,7 @@ import java.util.Map;
 public class MetadataConfigurationDBImporter {
 
     private IConvertDomainDBVisitor<Question, QuestionDB> converter;
+    private IConvertDomainDBVisitor<Option, OptionDB> converterOptions;
 
     private List<QuestionOptionDB> pendingOptionsWithRules = new ArrayList<>();
     private List<QuestionThresholdDB> pendingThresholdWithRules = new ArrayList<>();
@@ -49,9 +53,11 @@ public class MetadataConfigurationDBImporter {
 
     public MetadataConfigurationDBImporter(
             @NonNull IMetadataConfigurationDataSource remoteDataSource,
-            @NonNull IConvertDomainDBVisitor<Question, QuestionDB> converter) throws Exception {
+            @NonNull IConvertDomainDBVisitor<Question, QuestionDB> converter,
+            @NonNull IConvertDomainDBVisitor<Option, OptionDB> converterOptions) throws Exception {
         this.remoteDataSource = remoteDataSource;
         this.converter = converter;
+        this.converterOptions = converterOptions;
         countryVersions = new ArrayList<>();
         needToDownloadMetadata = false;
     }
@@ -166,14 +172,14 @@ public class MetadataConfigurationDBImporter {
 
         String countryUID = country.getUid();
         int version = country.getVersion();
-        List<Question> questions = remoteDataSource.getQuestionsByCountryCode(country.getReference());
+        Metadata metadataByCountries = remoteDataSource.getQuestionsByCountryCode(country.getReference());
 
         if (isCountryNotAlreadyAdded(countryUID)) {
-            updateMetadataFor(questions,country);
+            updateMetadataFor(metadataByCountries, country);
 
         } else if (hasMetadataBeenUpdatedFor(countryUID, version)) {
             deletePreviousMetadata();
-            updateMetadataFor(questions,country);
+            updateMetadataFor(metadataByCountries, country);
         }
     }
 
@@ -185,9 +191,55 @@ public class MetadataConfigurationDBImporter {
         return !CountryVersionDB.isCountryAlreadyAdded(countryCode);
     }
 
-    private void updateMetadataFor(List<Question> questions ,Configuration.CountryVersion country) throws Exception {
+    private void updateMetadataFor(Metadata metadataByCountries, Configuration.CountryVersion country) throws Exception {
         saveInDB(country);
-        saveQuestionsInDB(questions, country);
+
+        saveQuestionsInDB(metadataByCountries, country);
+    }
+
+    private List<OptionDB> saveOptions(Metadata metadata, Question question) {
+            List<OptionDB> optionDBS = new ArrayList<>();
+            List<OptionDB> options = getOptionDBsFrom(metadata, question.getCode());
+            for (OptionDB optionDB : options) {
+                optionDB.getOptionAttributeDB().save();
+                optionDB.save();
+                optionDBS.add(optionDB);
+            }
+            return optionDBS;
+    }
+
+
+    @NotNull
+    private List<OptionDB> getOptionDBsFrom(@NotNull Metadata metadata, String questionUId) {
+        List<OptionDB> optionDBS = new ArrayList<>();
+            List<Option> options = metadata.getOptions().get(questionUId);
+            if (options != null && options.size() > 0) {
+                for (Option domainOption : options) {
+                    OptionDB newOptionDB = converterOptions.visit(domainOption);
+                    optionDBS.add(newOptionDB);
+
+                    if (domainOption.hasRules()) {
+
+                        List<Option.Rule> domainRules = domainOption.getRules();
+                        List<String> dbRules = convertTODBRulesFrom(domainRules);
+
+                        newOptionDB.setMatchQuestionsCode(dbRules);
+
+                    }
+
+                }
+            }
+        return optionDBS;
+    }
+
+    @NonNull
+    private List<String> convertTODBRulesFrom(@NonNull List<Option.Rule> domainRules) {
+        List<String> dbRules = new ArrayList<>();
+
+        for (Option.Rule domainRule : domainRules) {
+            dbRules.add(domainRule.getActionSubject().getCode());
+        }
+        return dbRules;
     }
 
     private void saveInDB(Configuration.CountryVersion domainCountry) {
@@ -196,12 +248,14 @@ public class MetadataConfigurationDBImporter {
         addProgramMetadata(domainCountry);
     }
 
-    private void saveQuestionsInDB(List<Question> questions, Configuration.CountryVersion country) {
-
-        for (Question question : questions) {
+    private void saveQuestionsInDB(Metadata metadata, Configuration.CountryVersion country) {
+        for(Question question : metadata.getQuestions()) {
+            List<OptionDB> optionDBs = saveOptions(metadata, question);
             QuestionDB questionDB = converter.visit(question);
             setQuestionRelations(questionDB, country);
-            save(questionDB);
+
+            saveQuestion(question, optionDBs, questionDB);
+            save(optionDBs, questionDB);
 
             mapQuestionsDBByCode.put(questionDB.getCode(), questionDB);
 
@@ -214,8 +268,21 @@ public class MetadataConfigurationDBImporter {
                 }
             }
         }
-
         addingRulesToQuestion();
+    }
+
+    private void saveQuestion(Question question, List<OptionDB> optionDBs, QuestionDB questionDB) {
+        AnswerDB answerDB = createAnswer(question.getCode(), optionDBs);
+        questionDB.setAnswer(answerDB);
+        questionDB.save();
+    }
+
+    private AnswerDB createAnswer(String name, List<OptionDB> optionDbs) {
+        AnswerDB answerDB = new AnswerDB();
+        answerDB.setName(name);
+        answerDB.setOptionDBs(optionDbs);
+        answerDB.save();
+        return answerDB;
     }
 
     private void addThreshold(QuestionDB questionDB, Question.Rule rule,
@@ -348,26 +415,11 @@ public class MetadataConfigurationDBImporter {
         return questionRelationDB;
     }
 
-    private void save(QuestionDB questionDB) {
-        AnswerDB answerDB = questionDB.getAnswerDB();
-        List<OptionDB> questionOptionDBS = answerDB.getOptionDBs();
-        answerDB.setName(questionDB.getCode());
-        answerDB.save();
-        questionDB.setAnswer(answerDB);
-        questionDB.save();
-
-        save(questionOptionDBS, questionDB);
-
-    }
-
     private void save(List<OptionDB> questionOptionDBS, QuestionDB questionDB) {
 
-        AnswerDB answerDB = questionDB.getAnswerDB();
-
         for (OptionDB optionDB : questionOptionDBS) {
-            optionDB.setAnswerDB(answerDB);
+            optionDB.setAnswerDB(questionDB.getAnswerDB());
             optionDB.save();
-
             if (optionDB.hasMatches()) {
 
                 QuestionOptionDB questionOptionDB = new QuestionOptionDB();

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationDBImporter.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationDBImporter.java
@@ -20,7 +20,6 @@ import org.eyeseetea.malariacare.data.database.model.QuestionRelationDB;
 import org.eyeseetea.malariacare.data.database.model.QuestionThresholdDB;
 import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.data.database.model.TabDB;
-import org.eyeseetea.malariacare.data.remote.IMetadataConfigurationDataSource;
 import org.eyeseetea.malariacare.data.sync.importer.IConvertDomainDBVisitor;
 import org.eyeseetea.malariacare.domain.entity.Configuration;
 import org.eyeseetea.malariacare.domain.entity.Option;

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationDataSourceFactory.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationDataSourceFactory.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 
 import org.eyeseetea.malariacare.data.database.datasources.SettingsDataSource;
-import org.eyeseetea.malariacare.data.remote.IMetadataConfigurationDataSource;
 import org.eyeseetea.malariacare.domain.boundary.repositories.ISettingsRepository;
 import org.eyeseetea.malariacare.domain.entity.Settings;
 import org.eyeseetea.malariacare.network.factory.HTTPClientFactory;

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/OptionLocalDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/OptionLocalDataSource.java
@@ -1,8 +1,26 @@
 package org.eyeseetea.malariacare.data.database.datasources;
 
+import com.raizlabs.android.dbflow.sql.language.Join;
+import com.raizlabs.android.dbflow.sql.language.Select;
+
+import org.eyeseetea.malariacare.data.database.model.AnswerDB;
+import org.eyeseetea.malariacare.data.database.model.AnswerDB_Table;
 import org.eyeseetea.malariacare.data.database.model.OptionDB;
+import org.eyeseetea.malariacare.data.database.model.OptionDB_Table;
+import org.eyeseetea.malariacare.data.database.model.QuestionDB;
+import org.eyeseetea.malariacare.data.database.model.QuestionDB_Table;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IOptionRepository;
 import org.eyeseetea.malariacare.domain.entity.Option;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.eyeseetea.malariacare.data.database.AppDatabase.answerAlias;
+import static org.eyeseetea.malariacare.data.database.AppDatabase.answerName;
+import static org.eyeseetea.malariacare.data.database.AppDatabase.optionAlias;
+import static org.eyeseetea.malariacare.data.database.AppDatabase.optionName;
+import static org.eyeseetea.malariacare.data.database.AppDatabase.questionAlias;
+import static org.eyeseetea.malariacare.data.database.AppDatabase.questionName;
 
 public class OptionLocalDataSource implements IOptionRepository {
     @Override
@@ -13,5 +31,33 @@ public class OptionLocalDataSource implements IOptionRepository {
         }
         optionDB = OptionDB.getById(optionDB.getId_option());//fix Option fields (dbflow bug)
         return new Option(optionDB.getId_option(), optionDB.getCode(), optionDB.getName());
+    }
+
+    @Override
+    public List<Option> getOptionsByQuestion(String questionUId) {
+        List<OptionDB> optionDBs = getOptionsDBByQuestion(questionUId);
+        if(optionDBs == null){
+            return null;
+        }
+        List<Option> options = new ArrayList<>();
+        for(OptionDB optionDB : optionDBs ){
+            optionDB = OptionDB.getById(optionDB.getId_option());//fix Option fields (dbflow bug)
+            options.add(new Option(optionDB.getId_option(), optionDB.getCode(), optionDB.getName()));
+        }
+        return options;
+    }
+
+
+    private List<OptionDB> getOptionsDBByQuestion(String questionUid) {
+        return new Select().from(OptionDB.class).as(optionName)
+                .join(AnswerDB.class, Join.JoinType.LEFT_OUTER).as(answerName)
+                .on(OptionDB_Table.id_answer_fk.withTable(optionAlias)
+                        .eq(AnswerDB_Table.id_answer.withTable(answerAlias)))
+                .join(QuestionDB.class, Join.JoinType.LEFT_OUTER).as(questionName)
+                .on(QuestionDB_Table.id_answer_fk.withTable(questionAlias)
+                        .eq(AnswerDB_Table.id_answer.withTable(answerAlias)))
+                .where(QuestionDB_Table.uid_question.withTable(questionAlias).eq(questionUid))
+                .orderBy(OptionDB_Table.name.withTable(optionAlias), true)
+                .queryList();
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/model/QuestionDB.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/model/QuestionDB.java
@@ -841,7 +841,7 @@ public class QuestionDB extends BaseModel {
         return mAnswerDB;
     }
 
-    public void setAnswerDB(Long id_answer) {
+    public void setAnswer(Long id_answer) {
         this.id_answer_fk = id_answer;
         this.mAnswerDB = null;
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/mappers/AttributeMapper.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/mappers/AttributeMapper.java
@@ -1,0 +1,46 @@
+package org.eyeseetea.malariacare.data.mappers;
+
+import org.eyeseetea.malariacare.data.database.model.OptionAttributeDB;
+import org.eyeseetea.malariacare.domain.entity.Option;
+
+public class AttributeMapper {
+    public static OptionAttributeDB getOptionAttributeDBFrom(Option.Attribute attribute){
+        return getAttributeFrom(attribute);
+    }
+
+    private static OptionAttributeDB getAttributeFrom(Option.Attribute attribute) {
+        OptionAttributeDB optionAttributeDB = new OptionAttributeDB();
+        optionAttributeDB.setId_option_attribute(attribute.getId());
+        optionAttributeDB.setBackground_colour(attribute.getBackgroundColour());
+        optionAttributeDB.setHorizontal_alignment(mapHorizontalAttribute(attribute.getHorizontalAlignment()));
+        optionAttributeDB.setVertical_alignment(mapVerticalAttribute(attribute.getVerticalAlignment()));
+        optionAttributeDB.setText_size(attribute.getTextSize());
+        return optionAttributeDB;
+    }
+
+    private static int mapVerticalAttribute(Option.Attribute.VerticalAlignment verticalAlignment) {
+        if(verticalAlignment.equals(Option.Attribute.VerticalAlignment.NONE)){
+            return 3;
+        }else if(verticalAlignment.equals(Option.Attribute.VerticalAlignment.TOP)){
+            return 0;
+        }else if(verticalAlignment.equals(Option.Attribute.VerticalAlignment.BOTTOM)){
+            return 2;
+        }else if(verticalAlignment.equals(Option.Attribute.VerticalAlignment.MIDDLE)){
+            return 1;
+        }
+        return 0;
+    }
+
+    private static int mapHorizontalAttribute(Option.Attribute.HorizontalAlignment horizontalAlignment) {
+        if(horizontalAlignment.equals(Option.Attribute.HorizontalAlignment.NONE)){
+            return 3;
+        }else if(horizontalAlignment.equals(Option.Attribute.HorizontalAlignment.CENTER)){
+            return 1;
+        }else if(horizontalAlignment.equals(Option.Attribute.HorizontalAlignment.LEFT)){
+            return 0;
+        }else if(horizontalAlignment.equals(Option.Attribute.HorizontalAlignment.RIGHT)){
+            return 2;
+        }
+        return 0;
+    }
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/data/mappers/ConnectVoucherValueMapper.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/mappers/ConnectVoucherValueMapper.java
@@ -41,8 +41,9 @@ public class ConnectVoucherValueMapper {
         if(question==null){
             return null;
         }
-        if(question.hasOptions()){
-            OptionLocalDataSource optionLocalDataSource = new OptionLocalDataSource();
+        OptionLocalDataSource optionLocalDataSource = new OptionLocalDataSource();
+        List<Option> options = optionLocalDataSource.getOptionsByQuestion(questionUId);
+        if(options != null && options.size()>0){
             Option option = optionLocalDataSource.recoveryOptionsByQuestionAndValue(questionUId, value);
             if(option!=null) {
                 return new Value(value, questionUId, option.getCode());

--- a/app/src/main/java/org/eyeseetea/malariacare/data/mappers/OptionConvertFromDomainVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/mappers/OptionConvertFromDomainVisitor.java
@@ -3,7 +3,6 @@ package org.eyeseetea.malariacare.data.mappers;
 
 import com.raizlabs.android.dbflow.annotation.NotNull;
 
-import org.eyeseetea.malariacare.data.database.model.OptionAttributeDB;
 import org.eyeseetea.malariacare.data.database.model.OptionDB;
 import org.eyeseetea.malariacare.data.sync.importer.IConvertDomainDBVisitor;
 import org.eyeseetea.malariacare.domain.entity.Option;
@@ -17,44 +16,8 @@ public class OptionConvertFromDomainVisitor implements
         OptionDB dbModel = new OptionDB();
         dbModel.setCode(domainModel.getCode());
         dbModel.setName(domainModel.getName());
-        dbModel.setOptionAttributeDB(getAttributeFrom(domainModel.getAttribute()));
+        dbModel.setOptionAttributeDB(AttributeMapper.getOptionAttributeDBFrom(domainModel.getAttribute()));
         return dbModel;
-    }
-
-    private OptionAttributeDB getAttributeFrom(Option.Attribute attribute) {
-        OptionAttributeDB optionAttributeDB = new OptionAttributeDB();
-        optionAttributeDB.setId_option_attribute(attribute.getId());
-        optionAttributeDB.setBackground_colour(attribute.getBackgroundColour());
-        optionAttributeDB.setHorizontal_alignment(mapHorizontalAttribute(attribute.getHorizontalAlignment()));
-        optionAttributeDB.setVertical_alignment(mapVerticalAttribute(attribute.getVerticalAlignment()));
-        optionAttributeDB.setText_size(attribute.getTextSize());
-        return optionAttributeDB;
-    }
-
-    private int mapVerticalAttribute(Option.Attribute.VerticalAlignment verticalAlignment) {
-        if(verticalAlignment.equals(Option.Attribute.VerticalAlignment.NONE)){
-            return 3;
-        }else if(verticalAlignment.equals(Option.Attribute.VerticalAlignment.TOP)){
-            return 0;
-        }else if(verticalAlignment.equals(Option.Attribute.VerticalAlignment.BOTTOM)){
-            return 2;
-        }else if(verticalAlignment.equals(Option.Attribute.VerticalAlignment.MIDDLE)){
-            return 1;
-        }
-        return 0;
-    }
-
-    private int mapHorizontalAttribute(Option.Attribute.HorizontalAlignment horizontalAlignment) {
-        if(horizontalAlignment.equals(Option.Attribute.HorizontalAlignment.NONE)){
-            return 3;
-        }else if(horizontalAlignment.equals(Option.Attribute.HorizontalAlignment.CENTER)){
-            return 1;
-        }else if(horizontalAlignment.equals(Option.Attribute.HorizontalAlignment.LEFT)){
-            return 0;
-        }else if(horizontalAlignment.equals(Option.Attribute.HorizontalAlignment.RIGHT)){
-            return 2;
-        }
-        return 0;
     }
 
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/mappers/OptionConvertFromDomainVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/mappers/OptionConvertFromDomainVisitor.java
@@ -3,6 +3,7 @@ package org.eyeseetea.malariacare.data.mappers;
 
 import com.raizlabs.android.dbflow.annotation.NotNull;
 
+import org.eyeseetea.malariacare.data.database.model.OptionAttributeDB;
 import org.eyeseetea.malariacare.data.database.model.OptionDB;
 import org.eyeseetea.malariacare.data.sync.importer.IConvertDomainDBVisitor;
 import org.eyeseetea.malariacare.domain.entity.Option;
@@ -16,11 +17,44 @@ public class OptionConvertFromDomainVisitor implements
         OptionDB dbModel = new OptionDB();
         dbModel.setCode(domainModel.getCode());
         dbModel.setName(domainModel.getName());
-        dbModel.setId_option_attribute_fk(getAttributeIdFrom(domainModel));
+        dbModel.setOptionAttributeDB(getAttributeFrom(domainModel.getAttribute()));
         return dbModel;
     }
 
-    private long getAttributeIdFrom(Option domainOption) {
-        return (domainOption.getAttribute() != null) ? domainOption.getAttribute().getId() : 0;
+    private OptionAttributeDB getAttributeFrom(Option.Attribute attribute) {
+        OptionAttributeDB optionAttributeDB = new OptionAttributeDB();
+        optionAttributeDB.setId_option_attribute(attribute.getId());
+        optionAttributeDB.setBackground_colour(attribute.getBackgroundColour());
+        optionAttributeDB.setHorizontal_alignment(mapHorizontalAttribute(attribute.getHorizontalAlignment()));
+        optionAttributeDB.setVertical_alignment(mapVerticalAttribute(attribute.getVerticalAlignment()));
+        optionAttributeDB.setText_size(attribute.getTextSize());
+        return optionAttributeDB;
     }
+
+    private int mapVerticalAttribute(Option.Attribute.VerticalAlignment verticalAlignment) {
+        if(verticalAlignment.equals(Option.Attribute.VerticalAlignment.NONE)){
+            return 3;
+        }else if(verticalAlignment.equals(Option.Attribute.VerticalAlignment.TOP)){
+            return 0;
+        }else if(verticalAlignment.equals(Option.Attribute.VerticalAlignment.BOTTOM)){
+            return 2;
+        }else if(verticalAlignment.equals(Option.Attribute.VerticalAlignment.MIDDLE)){
+            return 1;
+        }
+        return 0;
+    }
+
+    private int mapHorizontalAttribute(Option.Attribute.HorizontalAlignment horizontalAlignment) {
+        if(horizontalAlignment.equals(Option.Attribute.HorizontalAlignment.NONE)){
+            return 3;
+        }else if(horizontalAlignment.equals(Option.Attribute.HorizontalAlignment.CENTER)){
+            return 1;
+        }else if(horizontalAlignment.equals(Option.Attribute.HorizontalAlignment.LEFT)){
+            return 0;
+        }else if(horizontalAlignment.equals(Option.Attribute.HorizontalAlignment.RIGHT)){
+            return 2;
+        }
+        return 0;
+    }
+
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/mappers/QuestionConvertFromDomainVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/mappers/QuestionConvertFromDomainVisitor.java
@@ -1,11 +1,9 @@
 package org.eyeseetea.malariacare.data.mappers;
 
 
-import android.support.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.annotation.NotNull;
 
-import org.eyeseetea.malariacare.data.database.model.AnswerDB;
 import org.eyeseetea.malariacare.data.database.model.OptionDB;
 import org.eyeseetea.malariacare.data.database.model.PhoneFormatDB;
 import org.eyeseetea.malariacare.data.database.model.QuestionDB;
@@ -14,9 +12,6 @@ import org.eyeseetea.malariacare.domain.entity.Option;
 import org.eyeseetea.malariacare.domain.entity.PhoneFormat;
 import org.eyeseetea.malariacare.domain.entity.Question;
 import org.eyeseetea.malariacare.utils.Constants;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class QuestionConvertFromDomainVisitor implements
         IConvertDomainDBVisitor<Question, QuestionDB> {
@@ -44,7 +39,7 @@ public class QuestionConvertFromDomainVisitor implements
         dbModel.setForm_name(domainModel.getName());
         dbModel.setOutput(getOutFrom(domainModel.getType()));
         dbModel.setCompulsory(getCompulsoryFrom(domainModel.isCompulsory()));
-        dbModel.setAnswer(getAnswerDBFromDomain(domainModel));
+        dbModel.setAnswer(domainModel.getAnswerId());
         dbModel.setHeaderDB(getHeaderID(domainModel));
         dbModel.setTotalQuestions(1);
         dbModel.setVisible(getVisibilityFrom(domainModel));
@@ -53,12 +48,6 @@ public class QuestionConvertFromDomainVisitor implements
         dbModel.setPhoneFormatDB(getPhoneFormat(domainModel.getPhoneFormat()));
         dbModel.setDefaultValue(domainModel.getDefaultValue());
         return dbModel;
-    }
-
-    private AnswerDB getAnswerDBFromDomain(@NotNull Question domainModel) {
-        AnswerDB answerDB = new AnswerDB();
-        answerDB.setOptionDBs(getOptionDBsFrom(domainModel));
-        return answerDB;
     }
 
     private PhoneFormatDB getPhoneFormat(PhoneFormat domainPhoneFormat) {
@@ -148,41 +137,4 @@ public class QuestionConvertFromDomainVisitor implements
     private int getCompulsoryFrom(boolean mandatory) {
         return (mandatory) ? 1 : 0;
     }
-
-    @NotNull
-    private List<OptionDB> getOptionDBsFrom(@NotNull Question questionDomain) {
-        List<OptionDB> optionDBS = new ArrayList<>();
-
-        if (questionDomain.hasOptions()) {
-            for (Option domainOption : questionDomain.getOptions()) {
-
-                OptionDB newOptionDB = optionConverter.visit(domainOption);
-
-                optionDBS.add(newOptionDB);
-
-
-                if (domainOption.hasRules()) {
-
-                    List<Option.Rule> domainRules = domainOption.getRules();
-                    List<String> dbRules = convertTODBRulesFrom(domainRules);
-
-                    newOptionDB.setMatchQuestionsCode(dbRules);
-
-                }
-
-            }
-        }
-        return optionDBS;
-    }
-
-    @NonNull
-    private List<String> convertTODBRulesFrom(@NonNull List<Option.Rule> domainRules) {
-        List<String> dbRules = new ArrayList<>();
-
-        for (Option.Rule domainRule : domainRules) {
-            dbRules.add(domainRule.getActionSubject().getCode());
-        }
-        return dbRules;
-    }
-
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/mappers/QuestionConvertFromDomainVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/mappers/QuestionConvertFromDomainVisitor.java
@@ -39,7 +39,6 @@ public class QuestionConvertFromDomainVisitor implements
         dbModel.setForm_name(domainModel.getName());
         dbModel.setOutput(getOutFrom(domainModel.getType()));
         dbModel.setCompulsory(getCompulsoryFrom(domainModel.isCompulsory()));
-        dbModel.setAnswer(domainModel.getAnswerId());
         dbModel.setHeaderDB(getHeaderID(domainModel));
         dbModel.setTotalQuestions(1);
         dbModel.setVisible(getVisibilityFrom(domainModel));

--- a/app/src/main/java/org/eyeseetea/malariacare/data/mappers/QuestionMapper.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/mappers/QuestionMapper.java
@@ -19,25 +19,6 @@ public class QuestionMapper {
     }
 
     public static Question mapFromDbToDomainWithValue(QuestionDB questionDB, Value value) {
-        List<Option> options = new ArrayList<>();
-        List<OptionDB> optionDBS = questionDB.getOptions();
-        for(OptionDB optionDB : optionDBS) {
-            OptionAttributeDB optionAttributeDB = optionDB.getOptionAttributeDB();
-            Option.Attribute attribute = null;
-            if(optionAttributeDB!=null) {
-                attribute = Option.Attribute.newBuilder()
-                        .id(optionAttributeDB.getId_option_attribute())
-                        .backgroundColour(optionAttributeDB.getBackground_colour())
-                        .verticalAlignment(mapOptionVerticalAttribute(optionAttributeDB.getVertical_alignment()))
-                        .horizontalAlignment(mapOptionHorizontalAttribute(optionAttributeDB.getHorizontal_alignment()))
-                        .textSize(optionDB.getOptionAttributeDB().getText_size()).build();
-            }
-            options.add( Option.newBuilder()
-                    .id(optionDB.getId_option())
-                    .code(optionDB.getCode())
-                    .name(optionDB.getName())
-                    .attribute(attribute).build());
-        }
         if(value==null) {
             return Question.newBuilder()
                     .id(questionDB.getId_question())
@@ -45,10 +26,10 @@ public class QuestionMapper {
                     .name(questionDB.getForm_name())
                     .uid(questionDB.getUid())
                     .type(mapOutputToQuestionType(questionDB.getOutput()))
-                    .options(options)
                     .regExp(questionDB.getValidationRegExp())
                     .regExpError(questionDB.getValidationMessage())
                     .compulsory(questionDB.isCompulsory())
+                    .answerId(questionDB.getId_answer_fk())
                     .build();
         }else{
             return Question.newBuilder()
@@ -57,52 +38,13 @@ public class QuestionMapper {
                     .name(questionDB.getForm_name())
                     .uid(questionDB.getUid())
                     .type(mapOutputToQuestionType(questionDB.getOutput()))
-                    .options(options)
                     .regExp(questionDB.getValidationRegExp())
                     .regExpError(questionDB.getValidationMessage())
                     .compulsory(questionDB.isCompulsory())
                     .value(value)
+                    .answerId(questionDB.getId_answer_fk())
                     .build();
         }
-    }
-
-    private static Option.Attribute.VerticalAlignment mapOptionVerticalAttribute(int verticalAlignment) {
-        Option.Attribute.VerticalAlignment verticalAlignmentEnum = Option.Attribute.VerticalAlignment.NONE;
-
-        switch (verticalAlignment) {
-            case OptionAttributeDB.VERTICAL_ALIGNMENT_BOTTOM:
-                verticalAlignmentEnum = Option.Attribute.VerticalAlignment.BOTTOM;
-                break;
-            case OptionAttributeDB.VERTICAL_ALIGNMENT_MIDDLE:
-                verticalAlignmentEnum = Option.Attribute.VerticalAlignment.MIDDLE;
-                break;
-            case OptionAttributeDB.VERTICAL_ALIGNMENT_NONE:
-                verticalAlignmentEnum = Option.Attribute.VerticalAlignment.NONE;
-                break;
-            case OptionAttributeDB.VERTICAL_ALIGNMENT_TOP:
-                verticalAlignmentEnum = Option.Attribute.VerticalAlignment.TOP;
-                break;
-        }
-        return verticalAlignmentEnum;
-    }
-
-    private static Option.Attribute.HorizontalAlignment mapOptionHorizontalAttribute(int horizontalAlignment) {
-        Option.Attribute.HorizontalAlignment horizontalAlignmentEnum = Option.Attribute.HorizontalAlignment.NONE;
-        switch (horizontalAlignment) {
-            case OptionAttributeDB.HORIZONTAL_ALIGNMENT_LEFT:
-                horizontalAlignmentEnum = Option.Attribute.HorizontalAlignment.LEFT;
-                break;
-            case OptionAttributeDB.HORIZONTAL_ALIGNMENT_RIGHT:
-                horizontalAlignmentEnum = Option.Attribute.HorizontalAlignment.RIGHT;
-                break;
-            case OptionAttributeDB.HORIZONTAL_ALIGNMENT_CENTER:
-                horizontalAlignmentEnum = Option.Attribute.HorizontalAlignment.CENTER;
-                break;
-            case OptionAttributeDB.HORIZONTAL_ALIGNMENT_NONE:
-                horizontalAlignmentEnum = Option.Attribute.HorizontalAlignment.NONE;
-                break;
-        }
-        return horizontalAlignmentEnum;
     }
 
     private static Question.Type mapOutputToQuestionType(int output) {

--- a/app/src/main/java/org/eyeseetea/malariacare/data/mappers/QuestionMapper.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/mappers/QuestionMapper.java
@@ -29,7 +29,6 @@ public class QuestionMapper {
                     .regExp(questionDB.getValidationRegExp())
                     .regExpError(questionDB.getValidationMessage())
                     .compulsory(questionDB.isCompulsory())
-                    .answerId(questionDB.getId_answer_fk())
                     .build();
         }else{
             return Question.newBuilder()
@@ -42,7 +41,6 @@ public class QuestionMapper {
                     .regExpError(questionDB.getValidationMessage())
                     .compulsory(questionDB.isCompulsory())
                     .value(value)
-                    .answerId(questionDB.getId_answer_fk())
                     .build();
         }
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/IMetadataConfigurationDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/IMetadataConfigurationDataSource.java
@@ -1,14 +1,14 @@
 package org.eyeseetea.malariacare.data.remote;
 
 
+import org.eyeseetea.malariacare.data.sync.importer.metadata.configuration.Metadata;
 import org.eyeseetea.malariacare.domain.entity.Configuration;
-import org.eyeseetea.malariacare.domain.entity.Question;
 
 import java.util.List;
 
 public interface IMetadataConfigurationDataSource {
 
-    List<Question> getQuestionsByCountryCode(String countryCode) throws Exception;
+    Metadata getQuestionsByCountryCode(String countryCode) throws Exception;
 
     List<Configuration.CountryVersion> getCountriesVersions() throws Exception;
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/boundary/repositories/IOptionRepository.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/boundary/repositories/IOptionRepository.java
@@ -2,6 +2,9 @@ package org.eyeseetea.malariacare.domain.boundary.repositories;
 
 import org.eyeseetea.malariacare.domain.entity.Option;
 
+import java.util.List;
+
 public interface IOptionRepository {
     Option recoveryOptionsByQuestionAndValue(String questionUId, String value);
+    List<Option> getOptionsByQuestion(String questionUId);
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Question.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Question.java
@@ -15,8 +15,8 @@ public class Question {
     private PhoneFormat phoneFormat;
     private Type type;
     private boolean compulsory;
-    private List<Option> options;
     private Header header;
+    private long answerId;
     private int index;
     private Visibility visibility;
     private List<Rule> rules;
@@ -26,11 +26,10 @@ public class Question {
     private String defaultValue;
 
     public Question(long id, String code, String name, String uid,
-            PhoneFormat phoneFormat, Type type, boolean compulsory,
-            List<Option> options, Header header, int index,
-            Visibility visibility,
-            List<Rule> rules, Value value, String regExp,
-            String regExpError, String defaultValue) {
+                    PhoneFormat phoneFormat, Type type, boolean compulsory,
+                    Header header, int index, Visibility visibility,
+                    List<Rule> rules, Value value, String regExp,
+                    String regExpError, String defaultValue, long answerId) {
 
         this.id = required(id, "id is required");
         this.code = required(code, "code is required");
@@ -39,7 +38,6 @@ public class Question {
         this.phoneFormat = phoneFormat;
         this.type = required(type, "type is required");
         this.compulsory = compulsory;
-        this.options = options;
         this.header = header;
         this.index = index;
         this.visibility = visibility;
@@ -48,6 +46,7 @@ public class Question {
         this.regExp = regExp;
         this.regExpError = regExpError;
         this.defaultValue = defaultValue;
+        this.answerId = answerId;
     }
 
     public static Builder newBuilder() {
@@ -68,14 +67,6 @@ public class Question {
 
     public boolean isCompulsory() {
         return compulsory;
-    }
-
-    public List<Option> getOptions() {
-        return options;
-    }
-
-    public boolean hasOptions() {
-        return options != null && options.size()>0;
     }
 
     public Header getHeader() {
@@ -124,6 +115,10 @@ public class Question {
 
     public String getDefaultValue(){ return defaultValue;}
 
+    public long getAnswerId() {
+        return answerId;
+    }
+
     public void match(String value) throws RegExpValidationException {
         if (!value.matches(regExp)){
             throw new RegExpValidationException(value);
@@ -138,6 +133,7 @@ public class Question {
         Question question = (Question) o;
 
         if (id != question.id) return false;
+        if (answerId != question.answerId) return false;
         if (compulsory != question.compulsory) return false;
         if (index != question.index) return false;
         if (code != null ? !code.equals(question.code) : question.code != null) return false;
@@ -151,9 +147,6 @@ public class Question {
             return false;
         }
         if (type != question.type) return false;
-        if (options != null ? !options.equals(question.options) : question.options != null) {
-            return false;
-        }
         if (header != null ? !header.equals(question.header) : question.header != null) {
             return false;
         }
@@ -173,9 +166,9 @@ public class Question {
         result = 31 * result + (phoneFormat != null ? phoneFormat.hashCode() : 0);
         result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (compulsory ? 1 : 0);
-        result = 31 * result + (options != null ? options.hashCode() : 0);
         result = 31 * result + (header != null ? header.hashCode() : 0);
         result = 31 * result + index;
+        result = result + (int) (answerId ^ (answerId >>> 32));
         result = 31 * result + (visibility != null ? visibility.hashCode() : 0);
         result = 31 * result + (rules != null ? rules.hashCode() : 0);
         return result;
@@ -191,12 +184,12 @@ public class Question {
                 ", phoneFormat=" + phoneFormat +
                 ", type=" + type +
                 ", compulsory=" + compulsory +
-                ", options=" + options +
                 ", header=" + header +
                 ", index=" + index +
                 ", visibility=" + visibility +
                 ", rules=" + rules +
                 ", regExp=" + regExp +
+                ", answerId=" + answerId +
                 ", regExpError=" + regExpError +
                 ", defaultValue=" + defaultValue +
                 '}';
@@ -219,12 +212,12 @@ public class Question {
         private PhoneFormat phoneFormat;
         private Type type;
         private boolean compulsory;
-        private List<Option> options;
         private Header header;
         private int index;
         private Visibility visibility;
         private List<Rule> rules;
         private long id;
+        private long answerId;
         private Value mValue;
         private String regExp;
         private String regExpError;
@@ -235,6 +228,11 @@ public class Question {
 
         public Builder code(String val) {
             code = val;
+            return this;
+        }
+
+        public Builder answerId(long id) {
+            answerId = id;
             return this;
         }
 
@@ -260,11 +258,6 @@ public class Question {
 
         public Builder compulsory(boolean val) {
             compulsory = val;
-            return this;
-        }
-
-        public Builder options(List<Option> val) {
-            options = val;
             return this;
         }
 
@@ -316,7 +309,6 @@ public class Question {
                     this.phoneFormat,
                     this.type,
                     this.compulsory,
-                    this.options,
                     this.header,
                     this.index,
                     this.visibility,
@@ -324,7 +316,8 @@ public class Question {
                     mValue,
                     this.regExp,
                     this.regExpError,
-                    this.defaultValue
+                    this.defaultValue,
+                    this.answerId
             );
         }
 

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Question.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Question.java
@@ -16,7 +16,6 @@ public class Question {
     private Type type;
     private boolean compulsory;
     private Header header;
-    private long answerId;
     private int index;
     private Visibility visibility;
     private List<Rule> rules;
@@ -29,7 +28,7 @@ public class Question {
                     PhoneFormat phoneFormat, Type type, boolean compulsory,
                     Header header, int index, Visibility visibility,
                     List<Rule> rules, Value value, String regExp,
-                    String regExpError, String defaultValue, long answerId) {
+                    String regExpError, String defaultValue) {
 
         this.id = required(id, "id is required");
         this.code = required(code, "code is required");
@@ -46,7 +45,6 @@ public class Question {
         this.regExp = regExp;
         this.regExpError = regExpError;
         this.defaultValue = defaultValue;
-        this.answerId = answerId;
     }
 
     public static Builder newBuilder() {
@@ -115,10 +113,6 @@ public class Question {
 
     public String getDefaultValue(){ return defaultValue;}
 
-    public long getAnswerId() {
-        return answerId;
-    }
-
     public void match(String value) throws RegExpValidationException {
         if (!value.matches(regExp)){
             throw new RegExpValidationException(value);
@@ -133,7 +127,6 @@ public class Question {
         Question question = (Question) o;
 
         if (id != question.id) return false;
-        if (answerId != question.answerId) return false;
         if (compulsory != question.compulsory) return false;
         if (index != question.index) return false;
         if (code != null ? !code.equals(question.code) : question.code != null) return false;
@@ -168,7 +161,6 @@ public class Question {
         result = 31 * result + (compulsory ? 1 : 0);
         result = 31 * result + (header != null ? header.hashCode() : 0);
         result = 31 * result + index;
-        result = result + (int) (answerId ^ (answerId >>> 32));
         result = 31 * result + (visibility != null ? visibility.hashCode() : 0);
         result = 31 * result + (rules != null ? rules.hashCode() : 0);
         return result;
@@ -189,7 +181,6 @@ public class Question {
                 ", visibility=" + visibility +
                 ", rules=" + rules +
                 ", regExp=" + regExp +
-                ", answerId=" + answerId +
                 ", regExpError=" + regExpError +
                 ", defaultValue=" + defaultValue +
                 '}';
@@ -217,7 +208,6 @@ public class Question {
         private Visibility visibility;
         private List<Rule> rules;
         private long id;
-        private long answerId;
         private Value mValue;
         private String regExp;
         private String regExpError;
@@ -228,11 +218,6 @@ public class Question {
 
         public Builder code(String val) {
             code = val;
-            return this;
-        }
-
-        public Builder answerId(long id) {
-            answerId = id;
             return this;
         }
 
@@ -316,8 +301,7 @@ public class Question {
                     mValue,
                     this.regExp,
                     this.regExpError,
-                    this.defaultValue,
-                    this.answerId
+                    this.defaultValue
             );
         }
 

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/DynamicTabAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/DynamicTabAdapter.java
@@ -86,7 +86,6 @@ import org.eyeseetea.malariacare.views.question.IMultiQuestionView;
 import org.eyeseetea.malariacare.views.question.INavigationQuestionView;
 import org.eyeseetea.malariacare.views.question.IQuestionView;
 import org.eyeseetea.malariacare.views.question.multiquestion.DatePickerQuestionView;
-import org.eyeseetea.malariacare.views.question.multiquestion.OuTreeMultiQuestionView;
 import org.eyeseetea.malariacare.views.question.multiquestion.YearSelectorQuestionView;
 import org.eyeseetea.malariacare.views.question.singlequestion.ImageRadioButtonSingleQuestionView;
 import org.eyeseetea.malariacare.views.question.singlequestion.NumberSingleQuestionView;
@@ -619,7 +618,7 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
                         screenQuestionDB.getInternationalizedPath());
             }
             mDynamicTabAdapterStrategy.renderParticularSurvey(screenQuestionDB, surveyDB, questionView);
-            if(questionView instanceof CommonQuestionView && requireQuestionOptionValidations(questionView)){
+            if(questionView instanceof CommonQuestionView){
                 ((CommonQuestionView) questionView).setQuestion(QuestionMapper.mapFromDbToDomain(screenQuestionDB));
             }
             if (questionView instanceof AOptionQuestionView) {
@@ -686,11 +685,6 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
                 ((CommonQuestionView) questionView).initContainers(tableRow, tableLayout);
             }
         }
-    }
-
-    //The OuTreeMultiQuestionView question don't required extra validations.
-    private boolean requireQuestionOptionValidations(IQuestionView questionView) {
-        return !(questionView instanceof OuTreeMultiQuestionView);
     }
 
     @Nullable

--- a/app/src/testEreferrals/java/org/eyeseetea/malariacare/data/database/convert/OptionConvertFromDomainVisitorShould.java
+++ b/app/src/testEreferrals/java/org/eyeseetea/malariacare/data/database/convert/OptionConvertFromDomainVisitorShould.java
@@ -1,9 +1,13 @@
 package org.eyeseetea.malariacare.data.database.convert;
 
+import android.support.annotation.NonNull;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
+import org.eyeseetea.malariacare.data.database.model.OptionAttributeDB;
 import org.eyeseetea.malariacare.data.database.model.OptionDB;
+import org.eyeseetea.malariacare.data.mappers.AttributeMapper;
 import org.eyeseetea.malariacare.data.mappers.OptionConvertFromDomainVisitor;
 import org.eyeseetea.malariacare.domain.entity.Option;
 import org.junit.Before;
@@ -36,6 +40,7 @@ public class OptionConvertFromDomainVisitorShould {
                 .newBuilder()
                 .code("FPL")
                 .name("common_option_program_familyPlanning")
+                .attribute(getDefaultAttribute())
                 .build();
     }
 
@@ -43,7 +48,7 @@ public class OptionConvertFromDomainVisitorShould {
         OptionDB optionDB = new OptionDB();
         optionDB.setCode("FPL");
         optionDB.setName("common_option_program_familyPlanning");
-
+        optionDB.setOptionAttributeDB(AttributeMapper.getOptionAttributeDBFrom(getDefaultAttribute()));
         return optionDB;
     }
 
@@ -52,5 +57,14 @@ public class OptionConvertFromDomainVisitorShould {
 
         assertThat(optionDBToEvaluate.getCode(), is(expectedOptionDB.getCode()));
         assertThat(optionDBToEvaluate.getName(), is(expectedOptionDB.getName()));
+    }
+
+    private Option.Attribute getDefaultAttribute() {
+        return Option.Attribute.newBuilder()
+                .id(1)
+                .backgroundColour("FFFFFF")
+                .horizontalAlignment(Option.Attribute.HorizontalAlignment.NONE)
+                .verticalAlignment(Option.Attribute.VerticalAlignment.NONE)
+                .textSize(20).build();
     }
 }

--- a/app/src/testEreferrals/java/org/eyeseetea/malariacare/data/database/convert/QuestionConvertFromDomainVisitorShould.java
+++ b/app/src/testEreferrals/java/org/eyeseetea/malariacare/data/database/convert/QuestionConvertFromDomainVisitorShould.java
@@ -328,7 +328,6 @@ public class QuestionConvertFromDomainVisitorShould {
                 .name("ipc_issueEntry_q_program")
                 .type(Question.Type.DROPDOWN_LIST)
                 .visibility(Question.Visibility.VISIBLE)
-                .options(options)
                 .compulsory(true).build();
 
         return question;

--- a/app/src/testEreferrals/java/org/eyeseetea/malariacare/data/sync/importer/MetadataConfigurationApiClientShould.java
+++ b/app/src/testEreferrals/java/org/eyeseetea/malariacare/data/sync/importer/MetadataConfigurationApiClientShould.java
@@ -16,6 +16,7 @@ import static org.hamcrest.core.Is.is;
 
 import org.eyeseetea.malariacare.common.FileReader;
 import org.eyeseetea.malariacare.data.server.CustomMockServer;
+import org.eyeseetea.malariacare.data.sync.importer.metadata.configuration.MetadataByCountry;
 import org.eyeseetea.malariacare.data.sync.importer.metadata.configuration
         .MetadataConfigurationApiClient;
 import org.eyeseetea.malariacare.domain.entity.Configuration;
@@ -39,7 +40,7 @@ public class MetadataConfigurationApiClientShould {
 
     private CustomMockServer CustomMockServer;
 
-    private List<Question> questions;
+    private MetadataByCountry metadataByCountry;
 
     private List<Configuration.CountryVersion> countryVersions;
 
@@ -115,19 +116,30 @@ public class MetadataConfigurationApiClientShould {
 
 
     private void thenAssertThatResponseParseSuccessfullyForMZCountry() {
-        validateQuestion(questions.get(0), givenAValidQuestionForMZ());
+        Question question = metadataByCountry.getQuestions().get(0);
+        validateQuestion(question, givenAValidQuestionForMZ());
+        validateOptions(metadataByCountry.getOptionsByQuestion(question.getCode()), givenAValidOptionsForMZ());
     }
 
     private void thenAssertThatResponseParseSuccessfullyForNPCountry() {
-        validateQuestion(questions.get(0), givenAValidQuestionForNP());
+        Question question = metadataByCountry.getQuestions().get(0);
+        validateQuestion(question, givenAValidQuestionForNP());
+        validateOptions(metadataByCountry.getOptionsByQuestion(question.getCode()), givenAValidOptionForNP());
+        validateQuestion(metadataByCountry.getQuestions().get(0), givenAValidQuestionForNP());
     }
 
     private void thenAssertThatResponseParseSuccessfullyForTZCountry() {
-        validateQuestion(questions.get(1), givenAValidQuestionForTZ());
+        Question question = metadataByCountry.getQuestions().get(1);
+        validateQuestion(question, givenAValidQuestionForTZ());
+        validateOptions(metadataByCountry.getOptionsByQuestion(question.getCode()), null);
+        validateQuestion(metadataByCountry.getQuestions().get(1), givenAValidQuestionForTZ());
     }
 
     private void thenAssertThatResponseParseSuccessfullyForZWCountry() {
-        validateQuestion(questions.get(3), givenAValidQuestionForZW());
+        Question question = metadataByCountry.getQuestions().get(3);
+        validateQuestion(question, givenAValidQuestionForZW());
+        validateOptions(metadataByCountry.getOptionsByQuestion(question.getCode()), null);
+        validateQuestion(metadataByCountry.getQuestions().get(3), givenAValidQuestionForZW());
     }
 
     private void thenAssertThatResponseParseSuccessfullyForCountryVersions() {
@@ -173,7 +185,7 @@ public class MetadataConfigurationApiClientShould {
 
         CustomMockServer.enqueueMockResponse(countryFile);
 
-        questions = apiClient.getQuestionsByCountryCode(countryCode);
+        metadataByCountry = apiClient.getQuestionsByCountryCode(countryCode);
 
     }
 
@@ -187,14 +199,16 @@ public class MetadataConfigurationApiClientShould {
         assertThat(questionToValidate.getType(), is(expectedQuestion.getType()));
 
         assertThat(questionToValidate.isCompulsory(), is(expectedQuestion.isCompulsory()));
+    }
 
-        if (expectedQuestion.getOptions() != null) {
-            assertThat(questionToValidate.getOptions(), is(notNullValue()));
+    private void validateOptions(List<Option> optionsToValidate, List<Option> expectedOptions){
+        if (expectedOptions != null) {
+            assertThat(optionsToValidate, is(notNullValue()));
 
-            for (int i = 0; i < expectedQuestion.getOptions().size(); i++) {
+            for (int i = 0; i < expectedOptions.size(); i++) {
 
-                Option validOption = expectedQuestion.getOptions().get(i);
-                Option toValidateOption = questionToValidate.getOptions().get(i);
+                Option validOption = expectedOptions.get(i);
+                Option toValidateOption = optionsToValidate.get(i);
 
                 assertThat(toValidateOption.getCode(), is(validOption.getCode()));
                 assertThat(toValidateOption.getName(), is(validOption.getName()));
@@ -211,18 +225,19 @@ public class MetadataConfigurationApiClientShould {
                 .name("ipc_issueEntry_q_program")
                 .type(Question.Type.DROPDOWN_LIST)
                 .compulsory(true)
-                .options(new ArrayList<Option>(1))
                 .build();
 
+        return mzQuestion;
+    }
+
+    private List<Option> givenAValidOptionsForMZ() {
         Option firstOption = Option
                 .newBuilder()
                 .code("FPL")
                 .name("common_option_program_familyPlanning")
                 .build();
 
-        mzQuestion.getOptions().add(firstOption);
-
-        return mzQuestion;
+        return createListOption(firstOption);
     }
 
     private Question givenAValidQuestionForNP() {
@@ -235,18 +250,19 @@ public class MetadataConfigurationApiClientShould {
                 .type(Question.Type.DROPDOWN_LIST)
                 .compulsory(true)
                 .visibility(Question.Visibility.VISIBLE)
-                .options(new ArrayList<Option>(1))
                 .build();
 
+        return mzQuestion;
+    }
+
+    private List<Option> givenAValidOptionForNP() {
         Option firstOption = Option
                 .newBuilder()
                 .code("FPL")
                 .name("common_option_program_familyPlanning")
                 .build();
 
-        mzQuestion.getOptions().add(firstOption);
-
-        return mzQuestion;
+        return createListOption(firstOption);
     }
 
     private Question givenAValidQuestionForTZ() {
@@ -258,7 +274,6 @@ public class MetadataConfigurationApiClientShould {
                 .name("ipc_issueEntry_q_firstName")
                 .type(Question.Type.SHORT_TEXT)
                 .compulsory(true)
-                .options(null)
                 .build();
     }
 
@@ -271,7 +286,6 @@ public class MetadataConfigurationApiClientShould {
                 .name("ipc_issueEntry_q_age")
                 .type(Question.Type.INT)
                 .compulsory(true)
-                .options(null)
                 .regExp("^(\\d{2})$")
                 .regExpError("some_error_msg_ref")
                 .build();
@@ -286,5 +300,12 @@ public class MetadataConfigurationApiClientShould {
         enqueueMalformedJson();
 
         apiClient.getQuestionsByCountryCode("dc@MZ@v1");
+    }
+
+    private List<Option> createListOption(Option option)
+    {
+        List<Option> options = new ArrayList<>();
+        options.add(option);
+        return options;
     }
 }

--- a/app/src/testEreferrals/java/org/eyeseetea/malariacare/data/sync/importer/MetadataConfigurationApiClientShould.java
+++ b/app/src/testEreferrals/java/org/eyeseetea/malariacare/data/sync/importer/MetadataConfigurationApiClientShould.java
@@ -16,7 +16,7 @@ import static org.hamcrest.core.Is.is;
 
 import org.eyeseetea.malariacare.common.FileReader;
 import org.eyeseetea.malariacare.data.server.CustomMockServer;
-import org.eyeseetea.malariacare.data.sync.importer.metadata.configuration.MetadataByCountry;
+import org.eyeseetea.malariacare.data.sync.importer.metadata.configuration.Metadata;
 import org.eyeseetea.malariacare.data.sync.importer.metadata.configuration
         .MetadataConfigurationApiClient;
 import org.eyeseetea.malariacare.domain.entity.Configuration;
@@ -40,7 +40,7 @@ public class MetadataConfigurationApiClientShould {
 
     private CustomMockServer CustomMockServer;
 
-    private MetadataByCountry metadataByCountry;
+    private Metadata metadata;
 
     private List<Configuration.CountryVersion> countryVersions;
 
@@ -116,30 +116,30 @@ public class MetadataConfigurationApiClientShould {
 
 
     private void thenAssertThatResponseParseSuccessfullyForMZCountry() {
-        Question question = metadataByCountry.getQuestions().get(0);
+        Question question = metadata.getQuestions().get(0);
         validateQuestion(question, givenAValidQuestionForMZ());
-        validateOptions(metadataByCountry.getOptionsByQuestion(question.getCode()), givenAValidOptionsForMZ());
+        validateOptions(metadata.getOptionsByQuestion(question.getCode()), givenAValidOptionsForMZ());
     }
 
     private void thenAssertThatResponseParseSuccessfullyForNPCountry() {
-        Question question = metadataByCountry.getQuestions().get(0);
+        Question question = metadata.getQuestions().get(0);
         validateQuestion(question, givenAValidQuestionForNP());
-        validateOptions(metadataByCountry.getOptionsByQuestion(question.getCode()), givenAValidOptionForNP());
-        validateQuestion(metadataByCountry.getQuestions().get(0), givenAValidQuestionForNP());
+        validateOptions(metadata.getOptionsByQuestion(question.getCode()), givenAValidOptionForNP());
+        validateQuestion(metadata.getQuestions().get(0), givenAValidQuestionForNP());
     }
 
     private void thenAssertThatResponseParseSuccessfullyForTZCountry() {
-        Question question = metadataByCountry.getQuestions().get(1);
+        Question question = metadata.getQuestions().get(1);
         validateQuestion(question, givenAValidQuestionForTZ());
-        validateOptions(metadataByCountry.getOptionsByQuestion(question.getCode()), null);
-        validateQuestion(metadataByCountry.getQuestions().get(1), givenAValidQuestionForTZ());
+        validateOptions(metadata.getOptionsByQuestion(question.getCode()), null);
+        validateQuestion(metadata.getQuestions().get(1), givenAValidQuestionForTZ());
     }
 
     private void thenAssertThatResponseParseSuccessfullyForZWCountry() {
-        Question question = metadataByCountry.getQuestions().get(3);
+        Question question = metadata.getQuestions().get(3);
         validateQuestion(question, givenAValidQuestionForZW());
-        validateOptions(metadataByCountry.getOptionsByQuestion(question.getCode()), null);
-        validateQuestion(metadataByCountry.getQuestions().get(3), givenAValidQuestionForZW());
+        validateOptions(metadata.getOptionsByQuestion(question.getCode()), null);
+        validateQuestion(metadata.getQuestions().get(3), givenAValidQuestionForZW());
     }
 
     private void thenAssertThatResponseParseSuccessfullyForCountryVersions() {
@@ -185,7 +185,7 @@ public class MetadataConfigurationApiClientShould {
 
         CustomMockServer.enqueueMockResponse(countryFile);
 
-        metadataByCountry = apiClient.getQuestionsByCountryCode(countryCode);
+        metadata = apiClient.getQuestionsByCountryCode(countryCode);
 
     }
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2318
* **Related pull-requests:**

### :tophat: What is the goal?

Remove option list from question.

### :memo: How is it being implemented?

The ereferrals api pull obtains an object with the list of questions and its options within each question.

To convert and save it i used a object called "Metadata" as wrapper of question and question option relation. And I did change the pull of Questions to pull of Metadata (with separated question and options with the question code as hashmap id in the case of the options).

In that process i needed change the order and way to save some data.

I needed replace the Question.hasOptions() method by a OptionLocalDataSource Query

I found (and fix) some bugs with the optionattributes( not correct colour value and not saved in database).

I moved "IMetadataConfigurationDataSource" file from main to ereferrals.

### :boom: How can it be tested?



 **Use case 1:** Test cnm pull (login on settings, HC, and send a survey), and the load of village question
 **Use case 2:** Test Ereferrals pull. Send a survey.
 **Use case 2:** Run ereferrals tests (remember move to ereferrals staging variant"

Note: in the case of ereferrals i compare the databases too to see if the result is correct with the user 8001.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-