### PR TITLE
Maintenance bug not show downloaded languages

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/database/datasources/LanguagesLocalDataSource.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/database/datasources/LanguagesLocalDataSource.java
@@ -3,11 +3,32 @@ package org.eyeseetea.malariacare.data.database.datasources;
 import org.eyeseetea.malariacare.data.database.model.TranslationDB;
 import org.eyeseetea.malariacare.data.database.model.TranslationLanguageDB;
 import org.eyeseetea.malariacare.domain.boundary.repositories.ILanguageRepository;
+import org.eyeseetea.malariacare.domain.entity.Language;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class LanguagesLocalDataSource implements ILanguageRepository {
     @Override
     public boolean translationsWereDownloaded() {
         return !TranslationLanguageDB.isEmpty()
                 && !TranslationDB.isEmpty();
+    }
+
+    @Override
+    public List<Language> getAllLanguage() {
+        List<TranslationLanguageDB> translationLanguageDBS =
+                TranslationLanguageDB.getAllTranslationLanguages();
+        List<Language> languages = new ArrayList<>();
+        for (TranslationLanguageDB translationLanguageDB : translationLanguageDBS) {
+            languages.add(mapLanguageFromTranslationLanguageDB(translationLanguageDB));
+        }
+        return languages;
+    }
+
+    private Language mapLanguageFromTranslationLanguageDB(
+            TranslationLanguageDB translationLanguageDB) {
+        return new Language(translationLanguageDB.getLanguage_code(),
+                translationLanguageDB.getLanguage_name());
     }
 }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/boundary/repositories/ILanguageRepository.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/boundary/repositories/ILanguageRepository.java
@@ -1,7 +1,13 @@
 package org.eyeseetea.malariacare.domain.boundary.repositories;
 
+import org.eyeseetea.malariacare.domain.entity.Language;
+
+import java.util.List;
+
 public interface ILanguageRepository {
 
     boolean translationsWereDownloaded();
+
+    List<Language> getAllLanguage();
 
 }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/entity/Language.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/entity/Language.java
@@ -1,0 +1,22 @@
+package org.eyeseetea.malariacare.domain.entity;
+
+import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+
+public class Language {
+
+    private String code;
+    private String name;
+
+    public Language(String code, String name) {
+        this.code = required(code,"Code is required");
+        this.name = required(name,"Name is required");
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/usecase/GetAllLanguagesUseCase.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/usecase/GetAllLanguagesUseCase.java
@@ -1,0 +1,50 @@
+package org.eyeseetea.malariacare.domain.usecase;
+
+import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
+import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
+import org.eyeseetea.malariacare.domain.boundary.repositories.ILanguageRepository;
+import org.eyeseetea.malariacare.domain.entity.Language;
+
+import java.util.List;
+
+public class GetAllLanguagesUseCase implements UseCase {
+
+    private IAsyncExecutor mAsyncExecutor;
+    private IMainExecutor mMainExecutor;
+    private ILanguageRepository mLanguageRepository;
+    private Callback mCallback;
+
+    public interface Callback {
+        void onSuccess(List<Language> languages);
+    }
+
+    public GetAllLanguagesUseCase(
+            IAsyncExecutor asyncExecutor,
+            IMainExecutor mainExecutor,
+            ILanguageRepository languageRepository) {
+        mAsyncExecutor = asyncExecutor;
+        mMainExecutor = mainExecutor;
+        mLanguageRepository = languageRepository;
+    }
+
+    @Override
+    public void run() {
+        notifyOnSuccess(mLanguageRepository.getAllLanguage());
+    }
+
+    public void execute(Callback callback) {
+        mCallback = callback;
+        mAsyncExecutor.run(this);
+    }
+
+
+    private void notifyOnSuccess(final List<Language> allLanguages) {
+        mMainExecutor.run(new Runnable() {
+            @Override
+            public void run() {
+                mCallback.onSuccess(allLanguages);
+            }
+        });
+    }
+
+}

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/factories/GetAllLanguagesUseCaseFactory.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/factories/GetAllLanguagesUseCaseFactory.java
@@ -1,0 +1,19 @@
+package org.eyeseetea.malariacare.factories;
+
+import org.eyeseetea.malariacare.data.database.datasources.LanguagesLocalDataSource;
+import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
+import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
+import org.eyeseetea.malariacare.domain.boundary.repositories.ILanguageRepository;
+import org.eyeseetea.malariacare.domain.usecase.GetAllLanguagesUseCase;
+import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
+import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
+
+public class GetAllLanguagesUseCaseFactory {
+    IAsyncExecutor mAsyncExecutor = new AsyncExecutor();
+    IMainExecutor mMainExecutor = new UIThreadExecutor();
+    ILanguageRepository mLanguageRepository = new LanguagesLocalDataSource();
+
+    public GetAllLanguagesUseCase getGetLanguagesUseCase() {
+        return new GetAllLanguagesUseCase(mAsyncExecutor, mMainExecutor, mLanguageRepository);
+    }
+}

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/factories/LanguagesFactory.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/factories/LanguagesFactory.java
@@ -8,7 +8,7 @@ import org.eyeseetea.malariacare.domain.usecase.GetAllLanguagesUseCase;
 import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
 import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
 
-public class GetAllLanguagesUseCaseFactory {
+public class LanguagesFactory {
     IAsyncExecutor mAsyncExecutor = new AsyncExecutor();
     IMainExecutor mMainExecutor = new UIThreadExecutor();
     ILanguageRepository mLanguageRepository = new LanguagesLocalDataSource();

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
@@ -28,7 +28,7 @@ import org.eyeseetea.malariacare.domain.entity.Language;
 import org.eyeseetea.malariacare.domain.usecase.GetAllLanguagesUseCase;
 import org.eyeseetea.malariacare.domain.usecase.LogoutUseCase;
 import org.eyeseetea.malariacare.factories.AuthenticationFactoryStrategy;
-import org.eyeseetea.malariacare.factories.GetAllLanguagesUseCaseFactory;
+import org.eyeseetea.malariacare.factories.LanguagesFactory;
 import org.eyeseetea.malariacare.layout.listeners.LogoutAndLoginRequiredOnPreferenceClickListener;
 import org.eyeseetea.malariacare.services.PushService;
 import org.eyeseetea.malariacare.services.strategies.PushServiceStrategy;
@@ -265,10 +265,10 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
 
     @Override
     public void setLanguageOptions(final Preference preference) {
-        GetAllLanguagesUseCaseFactory getAllLanguagesUseCaseFactory =
-                new GetAllLanguagesUseCaseFactory();
+        LanguagesFactory languagesFactory =
+                new LanguagesFactory();
         GetAllLanguagesUseCase getAllLanguagesUseCase =
-                getAllLanguagesUseCaseFactory.getGetLanguagesUseCase();
+                languagesFactory.getGetLanguagesUseCase();
         getAllLanguagesUseCase.execute(new GetAllLanguagesUseCase.Callback() {
             @Override
             public void onSuccess(List<Language> languages) {

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
@@ -299,5 +299,20 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
         }
         listPreference.setEntries(languagesStrings);
         listPreference.setEntryValues(languagesCodes);
+        listPreference.setSummary(
+                getPositionOfCode(listPreference.getValue(), languagesCodes, languagesStrings));
+    }
+
+    private CharSequence getPositionOfCode(String value, CharSequence[] languagesCodes,
+            CharSequence[] languagesNames) {
+        if (languagesCodes != null && value != null) {
+            for (int i = 0; i < languagesCodes.length; i++) {
+                if (languagesCodes[i].equals(value)) {
+                    return languagesNames[i];
+                }
+            }
+        }
+        return settingsActivity.getResources().getStringArray(
+                R.array.languages_strings)[0];
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/SettingsActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/SettingsActivity.java
@@ -22,8 +22,6 @@ package org.eyeseetea.malariacare;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.res.Configuration;
-import android.content.res.Resources;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.ListPreference;
@@ -31,19 +29,16 @@ import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceManager;
-import android.util.DisplayMetrics;
 import android.util.Log;
 
+import org.eyeseetea.malariacare.data.database.model.TranslationLanguageDB;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.strategies.SettingsActivityStrategy;
 import org.eyeseetea.malariacare.utils.LanguageContextWrapper;
 import org.eyeseetea.malariacare.views.AutoCompleteEditTextPreference;
-import org.eyeseetea.sdk.presentation.styles.FontStyle;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * A {@link PreferenceActivity} that presents a set of application settings. On
@@ -124,11 +119,8 @@ public class SettingsActivity extends PreferenceActivity implements
     /**
      * Sets the application languages and populate the language in the preference
      */
-    private static void setLanguageOptions(Preference preference) {
-        ListPreference listPreference = (ListPreference) preference;
-
-        listPreference.setEntries(R.array.languages_strings);
-        listPreference.setEntryValues(R.array.languages_codes);
+    private void setLanguageOptions(Preference preference) {
+        mSettingsActivityStrategy.setLanguageOptions(preference);
     }
 
 

--- a/app/src/main/java/org/eyeseetea/malariacare/strategies/ASettingsActivityStrategy.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/strategies/ASettingsActivityStrategy.java
@@ -2,9 +2,11 @@ package org.eyeseetea.malariacare.strategies;
 
 
 import android.content.SharedPreferences;
+import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceScreen;
 
+import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.SettingsActivity;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.utils.Utils;
@@ -58,5 +60,11 @@ public abstract class ASettingsActivityStrategy {
             entries.add(Utils.getInternationalizedString(fontStyle.getTitle()));
             entryValues.add(String.valueOf(fontStyle.getResId()));
         }
+    }
+
+    public void setLanguageOptions(Preference preference){
+        ListPreference listPreference = (ListPreference) preference;
+        listPreference.setEntries(R.array.languages_strings);
+        listPreference.setEntryValues(R.array.languages_codes);
     }
 }

--- a/app/src/testEreferrals/java/org/eyeseetea/malariacare/domain/entity/LanguageShould.java
+++ b/app/src/testEreferrals/java/org/eyeseetea/malariacare/domain/entity/LanguageShould.java
@@ -1,6 +1,5 @@
 package org.eyeseetea.malariacare.domain.entity;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 import org.junit.Rule;
@@ -12,31 +11,31 @@ public class LanguageShould {
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void should_throw_exception_if_language_name_is_null() {
+    public void throw_exception_if_language_name_is_null() {
         thrown.expect(IllegalArgumentException.class);
         new Language("es", null);
     }
 
     @Test
-    public void should_throw_exception_if_language_code_is_null() {
+    public void throw_exception_if_language_code_is_null() {
         thrown.expect(IllegalArgumentException.class);
         new Language(null, "Spanish");
     }
 
     @Test
-    public void should_throw_exception_if_language_name_is_empty() {
+    public void throw_exception_if_language_name_is_empty() {
         thrown.expect(IllegalArgumentException.class);
         new Language("es", "");
     }
 
     @Test
-    public void should_throw_exception_if_language_code_is_empty() {
+    public void throw_exception_if_language_code_is_empty() {
         thrown.expect(IllegalArgumentException.class);
         new Language("", "Spanish");
     }
 
     @Test
-    public void should_return_language_code_and_name_correctly() {
+    public void return_language_code_and_name_correctly() {
         Language language = new Language("es", "Spanish");
         assertThat(language.getCode(), is("es"));
         assertThat(language.getName(),is("Spanish"));

--- a/app/src/testEreferrals/java/org/eyeseetea/malariacare/domain/entity/LanguageShould.java
+++ b/app/src/testEreferrals/java/org/eyeseetea/malariacare/domain/entity/LanguageShould.java
@@ -1,0 +1,45 @@
+package org.eyeseetea.malariacare.domain.entity;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class LanguageShould {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void should_throw_exception_if_language_name_is_null() {
+        thrown.expect(IllegalArgumentException.class);
+        new Language("es", null);
+    }
+
+    @Test
+    public void should_throw_exception_if_language_code_is_null() {
+        thrown.expect(IllegalArgumentException.class);
+        new Language(null, "Spanish");
+    }
+
+    @Test
+    public void should_throw_exception_if_language_name_is_empty() {
+        thrown.expect(IllegalArgumentException.class);
+        new Language("es", "");
+    }
+
+    @Test
+    public void should_throw_exception_if_language_code_is_empty() {
+        thrown.expect(IllegalArgumentException.class);
+        new Language("", "Spanish");
+    }
+
+    @Test
+    public void should_return_language_code_and_name_correctly() {
+        Language language = new Language("es", "Spanish");
+        assertThat(language.getCode(), is("es"));
+        assertThat(language.getName(),is("Spanish"));
+    }
+
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2324 
* **Related pull-requests:** 

### :tophat: What is the goal?

Solve bug that not shows all downloaded languages.

### :memo: How is it being implemented?

Getting the downloaded languages in settings activity instead of the fixed languages in strings.xml.

- [ ] **Use case 1:** Login in app with 8001 user, enter in settings and change the language, enter in a survey to check if ti's translated. Not al app strings are translated because now they use the static strings  in the strings.xml file.


### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
