### PR TITLE
Maintenance strings get internacionaliced

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/fragments/AVFragment.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/fragments/AVFragment.java
@@ -34,6 +34,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
+import android.widget.TextView;
 
 import org.eyeseetea.malariacare.BuildConfig;
 import org.eyeseetea.malariacare.R;
@@ -54,6 +55,7 @@ import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
 import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
 import org.eyeseetea.malariacare.presentation.presenters.MediaPresenter;
 import org.eyeseetea.malariacare.strategies.DashboardHeaderStrategy;
+import org.eyeseetea.malariacare.utils.Utils;
 import org.eyeseetea.sdk.presentation.views.CustomTextView;
 
 import java.io.File;
@@ -79,6 +81,9 @@ public class AVFragment extends Fragment implements MediaPresenter.View {
 
         mTextProgressView = (CustomTextView)rootView.findViewById(R.id.progress_text);
         mErrorMessage = (CustomTextView) rootView.findViewById(R.id.error_message);
+        TextView titleMessage= (TextView) rootView.findViewById(R.id.answer_subtitle);
+        mTextProgressView.setText(Utils.getInternationalizedString(R.string.av_progress,getActivity()));
+        titleMessage.setText(Utils.getInternationalizedString(R.string.av_library,getActivity()));
 
         initializeRecyclerView();
         initializeChangeModeButtons();
@@ -160,8 +165,8 @@ public class AVFragment extends Fragment implements MediaPresenter.View {
 
         if (isThereAnAppThatCanHandleThis(implicitIntent, getActivity())) {
             getActivity().startActivity(Intent.createChooser(implicitIntent,
-                    PreferencesState.getInstance().getContext().getString(
-                            R.string.feedback_view_image)));
+                    Utils.getInternationalizedString(
+                            R.string.feedback_view_image,getActivity())));
         } else {
             showToast(R.string.error_unable_to_find_app_than_can_open_file, getActivity());
         }
@@ -204,7 +209,7 @@ public class AVFragment extends Fragment implements MediaPresenter.View {
         if (mPresenter.canShowErrorMessage()) {
             mErrorMessage.setVisibility(hasError ? View.VISIBLE : View.GONE);
             if (hasError) {
-                mErrorMessage.setText(message);
+                mErrorMessage.setText(Utils.getInternationalizedString(message, getActivity()));
             }
         }else {
             mErrorMessage.setVisibility(View.GONE);

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/layout/utils/LayoutUtils.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/layout/utils/LayoutUtils.java
@@ -1,5 +1,6 @@
 package org.eyeseetea.malariacare.layout.utils;
 
+import android.content.Context;
 import android.graphics.drawable.ColorDrawable;
 import android.support.v7.app.ActionBar;
 import android.view.View;
@@ -13,6 +14,7 @@ import org.eyeseetea.malariacare.data.database.CredentialsLocalDataSource;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.domain.entity.Credentials;
 import org.eyeseetea.malariacare.network.ConnectivityStatus;
+import org.eyeseetea.malariacare.utils.Utils;
 
 /**
  * Created by idelcano on 01/11/2016.
@@ -43,15 +45,16 @@ public class LayoutUtils extends BaseLayoutUtils {
         actionBar.setBackgroundDrawable(myColor);
         TextView userName = (TextView) actionBar.getCustomView().findViewById(
                 R.id.action_bar_user);
+        Context context = userName.getContext();
         CredentialsLocalDataSource credentialsLocalDataSource = new CredentialsLocalDataSource();
         Credentials credentials = credentialsLocalDataSource.getLastValidCredentials();
         userName.setText(credentials.getUsername());
         TextView connection =
                 (TextView) actionBar.getCustomView().findViewById(
                         R.id.action_bar_connection_status);
-        connection.setText(
-                !ConnectivityStatus.isConnected(PreferencesState.getInstance().getContext())
-                        ? R.string.action_bar_offline : R.string.action_bar_online);
+        connection.setText(Utils.getInternationalizedString(
+                !ConnectivityStatus.isConnected(context)
+                        ? R.string.action_bar_offline : R.string.action_bar_online, context));
     }
 
 

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/BaseActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/BaseActivityStrategy.java
@@ -75,8 +75,8 @@ public class BaseActivityStrategy extends ABaseActivityStrategy {
             TextView connection =
                     (TextView) actionBar.getCustomView().findViewById(
                             R.id.action_bar_connection_status);
-            connection.setText(notConnected
-                    ? R.string.action_bar_offline : R.string.action_bar_online);
+            connection.setText(Utils.getInternationalizedString(notConnected
+                    ? R.string.action_bar_offline : R.string.action_bar_online, context));
             if (notConnected) {
                 comesFromNotConected = true;
                 Toast.makeText(mBaseActivity, notConnectedText, Toast.LENGTH_SHORT).show();
@@ -85,7 +85,9 @@ public class BaseActivityStrategy extends ABaseActivityStrategy {
                     showLoginIfUserReadOnlyMode();
                 }
                 comesFromNotConected = false;
-                Toast.makeText(mBaseActivity, R.string.online_status, Toast.LENGTH_SHORT).show();
+                Toast.makeText(mBaseActivity,
+                        Utils.getInternationalizedString(R.string.online_status, context),
+                        Toast.LENGTH_SHORT).show();
             }
             DashboardActivity.dashboardActivity.refreshStatus();
         }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/BaseActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/BaseActivityStrategy.java
@@ -79,7 +79,9 @@ public class BaseActivityStrategy extends ABaseActivityStrategy {
                     ? R.string.action_bar_offline : R.string.action_bar_online, context));
             if (notConnected) {
                 comesFromNotConected = true;
-                Toast.makeText(mBaseActivity, notConnectedText, Toast.LENGTH_SHORT).show();
+                Toast.makeText(mBaseActivity,
+                        Utils.getInternationalizedString(notConnectedText, context),
+                        Toast.LENGTH_SHORT).show();
             } else {
                 if(comesFromNotConected){
                     showLoginIfUserReadOnlyMode();
@@ -132,7 +134,21 @@ public class BaseActivityStrategy extends ABaseActivityStrategy {
     @Override
     public void onCreateOptionsMenu(Menu menu) {
         menu.add(Menu.NONE, MENU_ITEM_LOGOUT, MENU_ITEM_LOGOUT_ORDER,
-                mBaseActivity.getResources().getString(R.string.common_menu_logOff));
+                Utils.getInternationalizedString(R.string.common_menu_logOff, mBaseActivity));
+        menu.findItem(R.id.action_settings).setTitle(
+                Utils.getInternationalizedString(R.string.app_settings, mBaseActivity));
+        menu.findItem(R.id.action_about).setTitle(
+                Utils.getInternationalizedString(R.string.common_menu_about, mBaseActivity));
+        menu.findItem(R.id.action_copyright).setTitle(
+                Utils.getInternationalizedString(R.string.app_copyright, mBaseActivity));
+        menu.findItem(R.id.action_licenses).setTitle(
+                Utils.getInternationalizedString(R.string.app_software_licenses, mBaseActivity));
+        menu.findItem(R.id.action_eula).setTitle(
+                Utils.getInternationalizedString(R.string.app_EULA, mBaseActivity));
+        menu.findItem(R.id.export_db).setTitle(
+                Utils.getInternationalizedString(R.string.export_data_option_title, mBaseActivity));
+        menu.findItem(R.id.demo_mode).setTitle(
+                Utils.getInternationalizedString(R.string.run_in_demo_mode, mBaseActivity));
     }
 
     @Override
@@ -142,9 +158,12 @@ public class BaseActivityStrategy extends ABaseActivityStrategy {
         switch (id) {
             case MENU_ITEM_LOGOUT:
                 new AlertDialog.Builder(mBaseActivity)
-                        .setTitle(mBaseActivity.getString(R.string.common_menu_logOff))
-                        .setMessage(mBaseActivity.getString(R.string.dashboard_menu_logout_message))
-                        .setPositiveButton(android.R.string.yes,
+                        .setTitle(Utils.getInternationalizedString(R.string.common_menu_logOff,
+                                mBaseActivity))
+                        .setMessage(Utils.getInternationalizedString(
+                                R.string.dashboard_menu_logout_message, mBaseActivity))
+                        .setPositiveButton(Utils.getInternationalizedString(android.R.string.yes,
+                                mBaseActivity),
                                 new DialogInterface.OnClickListener() {
                                     public void onClick(DialogInterface arg0, int arg1) {
                                         if (mBaseActivity instanceof DashboardActivity) {
@@ -154,7 +173,8 @@ public class BaseActivityStrategy extends ABaseActivityStrategy {
                                         }
                                     }
                                 })
-                        .setNegativeButton(android.R.string.no,
+                        .setNegativeButton(Utils.getInternationalizedString(android.R.string.no,
+                                mBaseActivity),
                                 new DialogInterface.OnClickListener() {
                                     public void onClick(DialogInterface dialog, int which) {
                                         dialog.cancel();
@@ -295,11 +315,13 @@ public class BaseActivityStrategy extends ABaseActivityStrategy {
             public void onAppInfoLoaded(AppInfo appInfo) {
                 StringBuilder aboutBuilder = new StringBuilder();
                 aboutBuilder.append(
-                        String.format(context.getResources().getString(R.string.config_version),
+                        String.format(
+                                Utils.getInternationalizedString(R.string.config_version, context),
                                 appInfo.getConfigFileVersion()));
                 aboutBuilder.append("<br/>");
                 aboutBuilder.append(
-                        String.format(context.getResources().getString(R.string.metadata_update),
+                        String.format(
+                                Utils.getInternationalizedString(R.string.metadata_update, context),
                                 getUpdateDateFromAppInfo(appInfo)));
                 aboutBuilder.append(stringMessage);
                 final SpannableString linkedMessage = new SpannableString(

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/DashboardActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/DashboardActivityStrategy.java
@@ -17,6 +17,7 @@ import android.view.View;
 import android.view.animation.AnimationUtils;
 import android.widget.ImageView;
 import android.widget.TabHost;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.google.android.gms.common.GoogleApiAvailability;
@@ -82,6 +83,7 @@ import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
 import org.eyeseetea.malariacare.services.PushService;
 import org.eyeseetea.malariacare.services.strategies.PushServiceStrategy;
 import org.eyeseetea.malariacare.utils.Constants;
+import org.eyeseetea.malariacare.utils.Utils;
 
 import java.io.File;
 import java.util.Date;
@@ -169,7 +171,8 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
     }
 
     private void showToast(@StringRes int text) {
-        Toast.makeText(mDashboardActivity.getApplicationContext(), text,
+        Toast.makeText(mDashboardActivity.getApplicationContext(),
+                Utils.getInternationalizedString(text, mDashboardActivity),
                 Toast.LENGTH_LONG).show();
     }
 
@@ -230,7 +233,8 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
                 if (userAccount.canAddSurveys()) {
                     openNewSurvey(activity);
                 } else {
-                    showToast(activity.getResources().getString(R.string.new_survey_disable));
+                    showToast(Utils.getInternationalizedString(R.string.new_survey_disable,
+                            activity));
                 }
             }
         });
@@ -523,8 +527,8 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
                     downloadMedia();
                 } else {
                     Toast.makeText(mDashboardActivity.getApplicationContext(),
-                            mDashboardActivity.getApplicationContext().getString(
-                                    R.string.google_play_required),
+                            Utils.getInternationalizedString(
+                                    R.string.google_play_required, mDashboardActivity),
                             Toast.LENGTH_LONG);
                 }
                 break;
@@ -574,7 +578,8 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
                     }
 
                     mDashboardActivity.showException(mDashboardActivity, "", String.format(
-                            mDashboardActivity.getResources().getString(R.string.give_voucher),
+                            Utils.getInternationalizedString(R.string.give_voucher,
+                                    mDashboardActivity),
                             voucherUId), onClickListener);
                 }
             });
@@ -593,7 +598,9 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
                         elementController, new IExternalVoucherRegistry.SenderCallback() {
                     @Override
                     public void onNotInstalledApp() {
-                        Toast.makeText(context, context.getString(R.string.element_not_installed), Toast.LENGTH_LONG).show();
+                        Toast.makeText(context,
+                                Utils.getInternationalizedString(R.string.element_not_installed,
+                                        context), Toast.LENGTH_LONG).show();
                     }
                 });
                 elementSentVoucherUseCase.execute(voucherUId);
@@ -603,12 +610,12 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
 
     private boolean noIssueVoucher(SurveyDB survey) {
         OptionDB noIssueOption = survey.getOptionSelectedForQuestionCode(
-                mDashboardActivity.getString(R.string.issue_voucher_qc));
+                Utils.getInternationalizedString(R.string.issue_voucher_qc, mDashboardActivity));
         if (noIssueOption == null) {
             return false;
         }
         return noIssueOption.getName().equals(
-                mDashboardActivity.getString(R.string.no_voucher_on));
+                Utils.getInternationalizedString(R.string.no_voucher_on, mDashboardActivity));
     }
 
     private boolean hasPhone(SurveyDB survey) {

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/DashboardHeaderStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/DashboardHeaderStrategy.java
@@ -11,6 +11,7 @@ import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.fragments.DashboardSentFragment;
 import org.eyeseetea.malariacare.network.ConnectivityStatus;
+import org.eyeseetea.malariacare.utils.Utils;
 import org.eyeseetea.sdk.presentation.views.CustomTextView;
 
 import java.util.List;
@@ -55,8 +56,9 @@ public class DashboardHeaderStrategy extends ADashboardHeaderStrategy {
         boolean notConnected = !ConnectivityStatus.isConnected(
                 PreferencesState.getInstance().getContext());
         headerText = (TextView) headerView.findViewById(R.id.header_text);
-        headerText.setText(
-                notConnected ? R.string.unsent_dashboard_header_offline : R.string.online_status);
+        headerText.setText(Utils.getInternationalizedString(
+                notConnected ? R.string.unsent_dashboard_header_offline : R.string.online_status,
+                headerText.getContext()));
         return headerView;
     }
 

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/LoginActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/LoginActivityStrategy.java
@@ -16,6 +16,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import org.eyeseetea.malariacare.DashboardActivity;
@@ -29,8 +30,6 @@ import org.eyeseetea.malariacare.data.database.utils.PreferencesEReferral;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.data.database.utils.Session;
 import org.eyeseetea.malariacare.data.database.utils.populatedb.PopulateDB;
-import org.eyeseetea.malariacare.data.sync.importer.WSPullController;
-import org.eyeseetea.malariacare.domain.boundary.IPullController;
 import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
 import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IAuthRepository;
@@ -56,6 +55,7 @@ import org.eyeseetea.malariacare.factories.SyncFactoryStrategy;
 import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
 import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
 import org.eyeseetea.malariacare.receivers.AlarmPushReceiver;
+import org.eyeseetea.malariacare.utils.Utils;
 import org.eyeseetea.malariacare.views.question.CommonQuestionView;
 
 public class LoginActivityStrategy extends ALoginActivityStrategy {
@@ -159,7 +159,8 @@ public class LoginActivityStrategy extends ALoginActivityStrategy {
     }
 
     private void showToastAndClose(int error) {
-        Toast.makeText(loginActivity, error, Toast.LENGTH_LONG).show();
+        Toast.makeText(loginActivity, Utils.getInternationalizedString(error, loginActivity),
+                Toast.LENGTH_LONG).show();
         Runnable runnable = new Runnable() {
             @Override
             public void run() {
@@ -210,7 +211,8 @@ public class LoginActivityStrategy extends ALoginActivityStrategy {
         passwordEditText.setTransformationMethod(PasswordTransformationMethod.getInstance());
         final TextInputLayout passwordHint =
                 (TextInputLayout) loginActivity.findViewById(R.id.password_hint);
-        passwordHint.setHint(loginActivity.getResources().getText(R.string.login_password));
+        passwordHint.setHint(
+                Utils.getInternationalizedString(R.string.login_password, loginActivity));
 
         initTextFields();
 
@@ -325,6 +327,8 @@ public class LoginActivityStrategy extends ALoginActivityStrategy {
 
     private void initAdvancedOptionsButton() {
         advancedOptions = (Button) loginActivity.findViewById(R.id.advanced_options);
+        advancedOptions.setText(
+                Utils.getInternationalizedString(R.string.advanced_options, loginActivity));
 
         advancedOptions.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -348,6 +352,8 @@ public class LoginActivityStrategy extends ALoginActivityStrategy {
 
     private void initServerURLField() {
         serverURLContainer = loginActivity.findViewById(R.id.text_layout_server_url);
+        ((TextInputLayout) loginActivity.findViewById(R.id.text_layout_server_url)).setHint(
+                Utils.getInternationalizedString(R.string.server_url, loginActivity));
     }
 
     private void initPasswordField() {
@@ -357,7 +363,8 @@ public class LoginActivityStrategy extends ALoginActivityStrategy {
 
         TextInputLayout passwordHint =
                 (TextInputLayout) loginActivity.findViewById(R.id.password_hint);
-        passwordHint.setHint(loginActivity.getResources().getText(R.string.login_password));
+        passwordHint.setHint(
+                Utils.getInternationalizedString(R.string.login_password, loginActivity));
     }
 
     private void onForgotPassword() {
@@ -376,15 +383,18 @@ public class LoginActivityStrategy extends ALoginActivityStrategy {
                     @Override
                     public void onNetworkError() {
                         loginActivity.onFinishLoading(null);
-                        showMessageDialog(loginActivity.getString(R.string.network_error),
-                                loginActivity.getString(R.string.error_conflict_title));
+                        showMessageDialog(Utils.getInternationalizedString(R.string.network_error,
+                                loginActivity),
+                                Utils.getInternationalizedString(R.string.error_conflict_title,
+                                        loginActivity));
                     }
 
                     @Override
                     public void onError(String messages) {
                         loginActivity.onFinishLoading(null);
                         showMessageDialog(messages,
-                                loginActivity.getString(R.string.error_conflict_title));
+                                Utils.getInternationalizedString(R.string.error_conflict_title,
+                                        loginActivity));
                     }
                 });
 
@@ -550,7 +560,8 @@ public class LoginActivityStrategy extends ALoginActivityStrategy {
             public void onWarning(WarningException warning) {
                 Log.w(this.getClass().getSimpleName(), "onWarning " + warning.getMessage());
                 loginActivity.showError(
-                        loginActivity.getString(R.string.warning_message) + warning.getMessage());
+                        Utils.getInternationalizedString(R.string.warning_message, loginActivity)
+                                + warning.getMessage());
             }
 
             @Override
@@ -570,7 +581,9 @@ public class LoginActivityStrategy extends ALoginActivityStrategy {
         AlertDialog.Builder builder = new AlertDialog.Builder(loginActivity);
         builder.setTitle(title);
         builder.setMessage(message);
-        builder.setPositiveButton(R.string.provider_redeemEntry_msg_matchingOk,
+        builder.setPositiveButton(
+                Utils.getInternationalizedString(R.string.provider_redeemEntry_msg_matchingOk,
+                        loginActivity),
                 new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {
@@ -582,6 +595,7 @@ public class LoginActivityStrategy extends ALoginActivityStrategy {
 
     private void initDemoButton() {
         demoButton = (Button) loginActivity.findViewById(R.id.demo_login_button);
+        demoButton.setText(Utils.getInternationalizedString(R.string.demo_login, loginActivity));
 
         demoButton.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
@@ -83,12 +83,18 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
                         settingsActivity.getResources().getString(R.string.pref_cat_server));
         preferenceCategory.removePreference(preferenceScreen.findPreference(
                 settingsActivity.getResources().getString(R.string.org_unit)));
+
+        Preference drivePreference = preferenceScreen.findPreference(
+                settingsActivity.getResources().getString(R.string.drive_key));
+        Preference metadataPreference = preferenceScreen.findPreference(
+                settingsActivity.getResources().getString(R.string.check_metadata_key));
+        settingsActivity.translatePreferenceString(drivePreference);
+        settingsActivity.translatePreferenceString(metadataPreference);
         if (!PreferencesState.getInstance().isDevelopOptionActive()
                 || !BuildConfig.developerOptions) {
             preferenceCategory.removePreference(preferenceScreen.findPreference(
                     settingsActivity.getResources().getString(R.string.drive_key)));
-            preferenceCategory.removePreference(preferenceScreen.findPreference(
-                    settingsActivity.getResources().getString(R.string.check_metadata_key)));
+            preferenceCategory.removePreference(metadataPreference);
         }
 
         Preference serverUrlPreference = (Preference) settingsActivity.findPreference(
@@ -206,10 +212,26 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
 
     @Override
     public void addExtraPreferences() {
-        settingsActivity.bindPreferenceSummaryToValue(settingsActivity.findPreference(
-                settingsActivity.getString(R.string.web_service_url)));
-        settingsActivity.bindPreferenceSummaryToValue(
-                settingsActivity.findPreference(settingsActivity.getString(R.string.web_view_url)));
+        Preference webServiceUrlPreference = settingsActivity.findPreference(
+                settingsActivity.getString(R.string.web_service_url));
+        settingsActivity.bindPreferenceSummaryToValue(webServiceUrlPreference);
+        settingsActivity.translatePreferenceString(webServiceUrlPreference);
+        Preference webViewPreference = settingsActivity.findPreference(
+                settingsActivity.getString(R.string.web_view_url));
+        settingsActivity.bindPreferenceSummaryToValue(webViewPreference);
+        settingsActivity.translatePreferenceString(webViewPreference);
+        settingsActivity.translatePreferenceString(settingsActivity.findPreference(
+                settingsActivity.getString(R.string.program_configuration_url)));
+        settingsActivity.translatePreferenceString(settingsActivity.findPreference(
+                settingsActivity.getString(R.string.program_configuration_user)));
+        settingsActivity.translatePreferenceString(settingsActivity.findPreference(
+                settingsActivity.getString(R.string.program_configuration_pass)));
+        settingsActivity.translatePreferenceString(settingsActivity.findPreference(
+                settingsActivity.getString(R.string.allow_media_download_3g_key)));
+        settingsActivity.translatePreferenceString(settingsActivity.findPreference(
+                settingsActivity.getString(R.string.developer_option)));
+        settingsActivity.translatePreferenceString(settingsActivity.findPreference(
+                settingsActivity.getString(R.string.activate_elements_key)));
     }
 
     @Override

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
@@ -228,10 +228,17 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
                 settingsActivity.getString(R.string.program_configuration_pass)));
         settingsActivity.translatePreferenceString(settingsActivity.findPreference(
                 settingsActivity.getString(R.string.allow_media_download_3g_key)));
-        settingsActivity.translatePreferenceString(settingsActivity.findPreference(
-                settingsActivity.getString(R.string.developer_option)));
-        settingsActivity.translatePreferenceString(settingsActivity.findPreference(
-                settingsActivity.getString(R.string.activate_elements_key)));
+        Preference developerPreference = settingsActivity.findPreference(
+                settingsActivity.getString(R.string.developer_option));
+        settingsActivity.translatePreferenceString(developerPreference);
+        developerPreference.setSummary(
+                Utils.getInternationalizedString(R.string.developer_option_summary,
+                        settingsActivity));
+        Preference elementsPreference = settingsActivity.findPreference(
+                settingsActivity.getString(R.string.activate_elements_key));
+        settingsActivity.translatePreferenceString(elementsPreference);
+        elementsPreference.setSummary(
+                Utils.getInternationalizedString(R.string.activate_elements, settingsActivity));
     }
 
     @Override

--- a/app/src/ereferrals/res/layout/activity_login.xml
+++ b/app/src/ereferrals/res/layout/activity_login.xml
@@ -99,7 +99,9 @@
                         android:inputType="textUri" />
                 </android.support.design.widget.TextInputLayout>
 
-                <android.support.design.widget.TextInputLayout style="@style/TextInputLayout">
+                <android.support.design.widget.TextInputLayout
+                    android:id="@+id/username_hint"
+                    style="@style/TextInputLayout">
 
                     <org.eyeseetea.sdk.presentation.views.CustomEditText
                         android:id="@+id/edittext_username"

--- a/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
@@ -31,7 +31,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -48,10 +47,8 @@ import android.widget.TextView;
 
 import org.eyeseetea.malariacare.data.database.datasources.SurveyLocalDataSource;
 import org.eyeseetea.malariacare.data.database.model.SurveyDB;
-import org.eyeseetea.malariacare.data.database.model.UserDB;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.data.database.utils.Session;
-import org.eyeseetea.malariacare.domain.exception.ApiCallException;
 import org.eyeseetea.malariacare.domain.exception.LoadingNavigationControllerException;
 import org.eyeseetea.malariacare.domain.usecase.LogoutUseCase;
 import org.eyeseetea.malariacare.domain.usecase.RemoveSurveysInProgressUseCase;
@@ -61,13 +58,13 @@ import org.eyeseetea.malariacare.fragments.SurveyFragment;
 import org.eyeseetea.malariacare.layout.adapters.survey.DynamicTabAdapter;
 import org.eyeseetea.malariacare.layout.score.ScoreRegister;
 import org.eyeseetea.malariacare.layout.utils.LayoutUtils;
-import org.eyeseetea.malariacare.network.ServerAPIController;
 import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
 import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
 import org.eyeseetea.malariacare.receivers.AlarmPushReceiver;
 import org.eyeseetea.malariacare.services.SurveyService;
 import org.eyeseetea.malariacare.strategies.DashboardActivityStrategy;
 import org.eyeseetea.malariacare.utils.GradleVariantConfig;
+import org.eyeseetea.malariacare.utils.Utils;
 import org.eyeseetea.malariacare.views.dialog.AnnouncementMessageDialog;
 
 public class DashboardActivity extends BaseActivity {
@@ -472,10 +469,14 @@ public class DashboardActivity extends BaseActivity {
     public void confirmExitApp() {
         Log.d(TAG, "back pressed");
         new AlertDialog.Builder(this)
-                .setTitle(R.string.confirmation_really_exit_title)
-                .setMessage(R.string.confirmation_really_exit)
-                .setNegativeButton(android.R.string.no, null)
-                .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
+                .setTitle(Utils.getInternationalizedString(R.string.confirmation_really_exit_title,
+                        this))
+                .setMessage(
+                        Utils.getInternationalizedString(R.string.confirmation_really_exit, this))
+                .setNegativeButton(Utils.getInternationalizedString(android.R.string.no, this),
+                        null)
+                .setPositiveButton(Utils.getInternationalizedString(android.R.string.yes, this),
+                        new DialogInterface.OnClickListener() {
 
                     public void onClick(DialogInterface arg0, int arg1) {
                         Intent intent = new Intent(Intent.ACTION_MAIN);
@@ -496,8 +497,8 @@ public class DashboardActivity extends BaseActivity {
             int infoMessage = surveyDB.isInProgress() ? R.string.survey_info_exit_delete
                     : R.string.survey_info_exit;
             new AlertDialog.Builder(this)
-                    .setTitle(R.string.survey_info_exit)
-                    .setMessage(infoMessage)
+                    .setTitle(Utils.getInternationalizedString(R.string.survey_info_exit, this))
+                    .setMessage(Utils.getInternationalizedString(infoMessage, this))
                     .setNegativeButton(android.R.string.no, null)
                     .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int arg1) {
@@ -652,16 +653,18 @@ public class DashboardActivity extends BaseActivity {
 
     private void showSendSurveyDialog() {
         AlertDialog.Builder msgConfirmation = new AlertDialog.Builder(this)
-                .setTitle(R.string.survey_completed)
-                .setMessage(R.string.survey_completed_text)
+                .setTitle(Utils.getInternationalizedString(R.string.survey_completed, this))
+                .setMessage(Utils.getInternationalizedString(R.string.survey_completed_text, this))
                 .setCancelable(false)
-                .setPositiveButton(R.string.survey_send, new DialogInterface.OnClickListener() {
+                .setPositiveButton(Utils.getInternationalizedString(R.string.survey_send, this),
+                        new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int arg1) {
                         sendSurvey();
                         DynamicTabAdapter.isClicked = false;
                     }
                 });
-        msgConfirmation.setNegativeButton(R.string.survey_review,
+        msgConfirmation.setNegativeButton(
+                Utils.getInternationalizedString(R.string.survey_review, this),
                 new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int arg1) {
                         reviewSurvey();

--- a/app/src/main/java/org/eyeseetea/malariacare/LoginActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/LoginActivity.java
@@ -30,6 +30,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
+import android.support.design.widget.TextInputLayout;
 import android.support.v4.content.ContextCompat;
 import android.text.Editable;
 import android.text.Html;
@@ -103,6 +104,8 @@ public class LoginActivity extends Activity {
     // Callback which will be triggered when animations are finished
     private OnPostAnimationListener onPostAnimationListener;
 
+    private Context mContext;
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -116,6 +119,7 @@ public class LoginActivity extends Activity {
         if(BuildConfig.translations) {
             PreferencesState.getInstance().loadsLanguageInActivity();
         }
+        mContext = this;
     }
 
     private void initLoginUseCase() {
@@ -244,7 +248,8 @@ public class LoginActivity extends Activity {
         return super.onOptionsItemSelected(item);
     }
     public void showError(int message) {
-        Toast.makeText(this, message, Toast.LENGTH_LONG).show();
+        Toast.makeText(this, Utils.getInternationalizedString(message, this),
+                Toast.LENGTH_LONG).show();
     }
 
     @Override
@@ -263,6 +268,9 @@ public class LoginActivity extends Activity {
         //Username, Password blanks to force real login
         usernameEditText = (EditText) findViewById(R.id.edittext_username);
         usernameEditText.setText(DEFAULT_USER);
+        TextInputLayout userHint = (TextInputLayout) findViewById(R.id.username_hint);
+        userHint.setHint(
+                Utils.getInternationalizedString(R.string.login_userName, mContext));
         usernameEditText.addTextChangedListener(watcher);
         passwordEditText = (EditText) findViewById(R.id.edittext_password);
         passwordEditText.setText(DEFAULT_PASSWORD);
@@ -277,6 +285,7 @@ public class LoginActivity extends Activity {
                         passwordEditText.getText());
             }
         });
+        loginButton.setText(Utils.getInternationalizedString(R.string.login_btn_login, mContext));
 
         mLoginActivityStrategy.initViews();
     }
@@ -298,7 +307,8 @@ public class LoginActivity extends Activity {
             @Override
             public void onError() {
                 hideProgressBar();
-                showError(getString(R.string.login_unexpected_error));
+                showError(Utils.getInternationalizedString(R.string.login_unexpected_error,
+                        mContext));
             }
         });
 
@@ -317,8 +327,11 @@ public class LoginActivity extends Activity {
             public void onServerURLNotValid() {
                 Log.d(TAG, "onServerURLNotValid");
                 onFinishLoading(null);
-                serverText.setError(getString(R.string.login_invalid_server_url));
-                showError(getString(R.string.login_invalid_server_url));
+                serverText.setError(
+                        Utils.getInternationalizedString(R.string.login_invalid_server_url,
+                                mContext));
+                showError(Utils.getInternationalizedString(R.string.login_invalid_server_url,
+                        mContext));
             }
 
             @Override
@@ -343,14 +356,15 @@ public class LoginActivity extends Activity {
             public void onConfigJsonInvalid() {
                 Log.d(TAG, "onConfigJsonInvalid");
                 onFinishLoading(null);
-                showError(getString(R.string.login_error_json));
+                showError(Utils.getInternationalizedString(R.string.login_error_json, mContext));
             }
 
             @Override
             public void onUnexpectedError() {
                 Log.d(TAG, "onUnexpectedError");
                 hideProgressBar();
-                showError(getString(R.string.login_unexpected_error));
+                showError(Utils.getInternationalizedString(R.string.login_unexpected_error,
+                        mContext));
             }
 
             @Override

--- a/app/src/main/java/org/eyeseetea/malariacare/SettingsActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/SettingsActivity.java
@@ -332,7 +332,6 @@ public class SettingsActivity extends PreferenceActivity implements
     }
 
     public void translatePreferenceString(Preference preference) {
-        preference.setTitle(Utils.getInternationalizedString(
-                getResources().getResourceEntryName(preference.getTitleRes())));
+        preference.setTitle(Utils.getInternationalizedString(preference.getTitleRes(),this));
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/SettingsActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/SettingsActivity.java
@@ -31,10 +31,10 @@ import android.preference.PreferenceCategory;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
-import org.eyeseetea.malariacare.data.database.model.TranslationLanguageDB;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.strategies.SettingsActivityStrategy;
 import org.eyeseetea.malariacare.utils.LanguageContextWrapper;
+import org.eyeseetea.malariacare.utils.Utils;
 import org.eyeseetea.malariacare.views.AutoCompleteEditTextPreference;
 
 import java.util.ArrayList;
@@ -159,8 +159,11 @@ public class SettingsActivity extends PreferenceActivity implements
 
 
         if (BuildConfig.translations) {
-            setLanguageOptions(
-                    findPreference(getApplicationContext().getString(R.string.language_code)));
+            Preference languagePreference = findPreference(
+                    getApplicationContext().getString(R.string.language_code));
+            setLanguageOptions(languagePreference);
+
+            translatePreferenceString(languagePreference);
         }
 
         // Bind the summaries of EditText/List/Dialog/Ringtone preferences to
@@ -171,10 +174,13 @@ public class SettingsActivity extends PreferenceActivity implements
                     findPreference(getApplicationContext().getString(R.string.language_code)));
         }
 
-        bindPreferenceSummaryToValue(
-                findPreference(getApplicationContext().getString(R.string.font_sizes)));
-        bindPreferenceSummaryToValue(
-                findPreference(getApplicationContext().getString(R.string.org_unit)));
+        Preference fontSizePreference = findPreference(
+                getApplicationContext().getString(R.string.font_sizes));
+        bindPreferenceSummaryToValue(fontSizePreference);
+        translatePreferenceString(fontSizePreference);
+        Preference orgUnitPreference=findPreference(getApplicationContext().getString(R.string.org_unit));
+        bindPreferenceSummaryToValue(orgUnitPreference);
+        translatePreferenceString(orgUnitPreference);
 
         autoCompleteEditTextPreference = (AutoCompleteEditTextPreference) findPreference(
                 getApplicationContext().getString(R.string.org_unit));
@@ -190,8 +196,7 @@ public class SettingsActivity extends PreferenceActivity implements
             PreferenceCategory preferenceCategory =
                     (PreferenceCategory) getPreferenceScreen().findPreference(
                             this.getResources().getString(R.string.pref_visual));
-            preferenceCategory.removePreference(getPreferenceScreen().findPreference(
-                    this.getResources().getString(R.string.font_sizes)));
+            preferenceCategory.removePreference(fontSizePreference);
             preferenceCategory.removePreference(getPreferenceScreen().findPreference(
                     this.getResources().getString(R.string.customize_fonts)));
         }
@@ -218,6 +223,7 @@ public class SettingsActivity extends PreferenceActivity implements
         listPreference.setEntryValues(entryValues.toArray(new CharSequence[entryValues.size()]));
         CheckBoxPreference customizeFont = ((CheckBoxPreference)getPreferenceScreen().findPreference(
                 this.getResources().getString(R.string.customize_fonts)));
+        translatePreferenceString(customizeFont);
         if(customizeFont.isChecked()) {
             for(int i=0; listPreference.getEntryValues().length>i;i++){
                 if(listPreference.getEntryValues()[i].equals(listPreference.getValue())){
@@ -323,5 +329,10 @@ public class SettingsActivity extends PreferenceActivity implements
     protected void onRestart() {
         super.onRestart();
         Log.d(TAG, "AndroidLifeCycle: onRestart");
+    }
+
+    public void translatePreferenceString(Preference preference) {
+        preference.setTitle(Utils.getInternationalizedString(
+                getResources().getResourceEntryName(preference.getTitleRes())));
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/DynamicTabAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/DynamicTabAdapter.java
@@ -44,6 +44,7 @@ import android.widget.Spinner;
 import android.widget.Switch;
 import android.widget.TableLayout;
 import android.widget.TableRow;
+import android.widget.TextView;
 
 import org.eyeseetea.malariacare.BuildConfig;
 import org.eyeseetea.malariacare.DashboardActivity;
@@ -496,6 +497,8 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
 
         //QuestionDB
         CustomTextView headerView = (CustomTextView) rowView.findViewById(question);
+        ((TextView) rowView.findViewById(R.id.question_title)).setText(
+                Utils.getInternationalizedString(R.string.new_survey_title, context));
 
         //Load a font which support Khmer character
         Typeface tf = Typeface.createFromAsset(context.getAssets(),
@@ -865,6 +868,8 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
 
     private void initializeNavigationButtons(View navigationButtonsHolder) {
         View nextButton = (View) navigationButtonsHolder.findViewById(R.id.next_btn);
+        ((TextView) nextButton).setText(
+                Utils.getInternationalizedString(R.string.survey_submit, context));
 
         ((LinearLayout) nextButton.getParent()).setOnClickListener(new View.OnClickListener() {
             @Override
@@ -1147,10 +1152,12 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
      */
     public void surveyShowDone() {
         AlertDialog.Builder msgConfirmation = new AlertDialog.Builder(context)
-                .setTitle(R.string.survey_completed)
-                .setMessage(R.string.survey_completed_text)
+                .setTitle(Utils.getInternationalizedString(R.string.survey_completed, context))
+                .setMessage(
+                        Utils.getInternationalizedString(R.string.survey_completed_text, context))
                 .setCancelable(false)
-                .setPositiveButton(R.string.survey_send, new DialogInterface.OnClickListener() {
+                .setPositiveButton(Utils.getInternationalizedString(R.string.survey_send, context),
+                        new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int arg1) {
                         CommonQuestionView.hideKeyboard(PreferencesState.getInstance().getContext(),
                                 keyboardView);
@@ -1158,7 +1165,8 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
                         isClicked = false;
                     }
                 });
-        msgConfirmation.setNegativeButton(R.string.survey_review,
+        msgConfirmation.setNegativeButton(
+                Utils.getInternationalizedString(R.string.survey_review, context),
                 new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int arg1) {
                         CommonQuestionView.hideKeyboard(PreferencesState.getInstance().getContext(),

--- a/app/src/main/java/org/eyeseetea/malariacare/strategies/ADashboardActivityStrategy.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/strategies/ADashboardActivityStrategy.java
@@ -44,6 +44,7 @@ import org.eyeseetea.malariacare.layout.listeners.SurveyLocationListener;
 import org.eyeseetea.malariacare.layout.utils.LayoutUtils;
 import org.eyeseetea.malariacare.network.ServerAPIController;
 import org.eyeseetea.malariacare.utils.GradleVariantConfig;
+import org.eyeseetea.malariacare.utils.Utils;
 import org.eyeseetea.malariacare.views.dialog.AnnouncementMessageDialog;
 
 public abstract class ADashboardActivityStrategy {
@@ -357,6 +358,10 @@ public abstract class ADashboardActivityStrategy {
         for (int i = 0; i < tabHost.getTabWidget().getChildCount(); i++) {
             tabHost.getTabWidget().getChildAt(i).setFocusable(false);
         }
+
+
+        ((TextView) mDashboardActivity.findViewById(R.id.header_extra_info)).setText(
+                Utils.getInternationalizedString(R.string.unsent_vouchers, mDashboardActivity));
     }
 
     protected void setTabsBackgroundColor(int color, TabHost tabHost) {

--- a/app/src/main/java/org/eyeseetea/malariacare/strategies/ALoginActivityStrategy.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/strategies/ALoginActivityStrategy.java
@@ -30,7 +30,7 @@ public abstract class ALoginActivityStrategy {
 
     public void onBadCredentials() {
         loginActivity.hideProgressBar();
-        loginActivity.showError(loginActivity.getString(R.string.login_invalid_credentials));
+        loginActivity.showError(R.string.login_invalid_credentials);
     }
 
     public void onStart() {

--- a/app/src/main/java/org/eyeseetea/malariacare/utils/Utils.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/utils/Utils.java
@@ -78,6 +78,10 @@ public class Utils {
     }
 
 
+    public static String getInternationalizedString(int id, Context context) {
+        return getInternationalizedString(context.getResources().getResourceEntryName(id), context);
+    }
+
     @NonNull
     public static String getInternationalizedString(@NonNull String key) {
         Context context = PreferencesState.getInstance().getContext();

--- a/app/src/main/java/org/eyeseetea/malariacare/views/ViewUtils.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/ViewUtils.java
@@ -12,6 +12,8 @@ import android.widget.Toast;
 
 import com.raizlabs.android.dbflow.annotation.NotNull;
 
+import org.eyeseetea.malariacare.utils.Utils;
+
 public class ViewUtils {
 
     public static void toggleVisibility(View view) {
@@ -37,7 +39,7 @@ public class ViewUtils {
     }
 
     public static void showToast(@StringRes int titleResource, @NotNull Context context) {
-        final String title = context.getResources().getString(titleResource);
+        final String title = Utils.getInternationalizedString(titleResource, context);
         Toast.makeText(context, title, Toast.LENGTH_LONG).show();
     }
 

--- a/app/src/main/java/org/eyeseetea/malariacare/views/ViewUtils.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/ViewUtils.java
@@ -32,9 +32,9 @@ public class ViewUtils {
         String actualText = textView.getText().toString();
 
         if (actualText.equals(firstText)) {
-            textView.setText(idSecondText);
+            textView.setText(Utils.getInternationalizedString(idSecondText,context));
         } else {
-            textView.setText(idFirstText);
+            textView.setText(Utils.getInternationalizedString(idFirstText,context));
         }
     }
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2332 
* **Related pull-requests:** 

### :tophat: What is the goal?

Make all strings in the app use getInternationalizedString() to always use POEditor terms

### :memo: How is it being implemented?

Using the meths getInternationalizedString to translate connect Strings. 

### :boom: How can it be tested?

- [ ] **Use case 1:** Login in app with 8001 user, select Spanish and check if all the strings are translated, if are some strings not translated, check the database to see if there is a translation.


### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
