### PR TITLE
show first language on settings languages

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SettingsActivityStrategy.java
@@ -318,13 +318,15 @@ public class SettingsActivityStrategy extends ASettingsActivityStrategy {
                         R.array.languages_strings)[0];
         CharSequence systemDefinedCode = settingsActivity.getResources().getStringArray(
                 R.array.languages_codes)[0];
-        CharSequence[] languagesStrings = new CharSequence[languages.size()];
-        CharSequence[] languagesCodes = new CharSequence[languages.size()];
+        CharSequence[] languagesStrings = new CharSequence[languages.size()+1];
+        CharSequence[] languagesCodes = new CharSequence[languages.size()+1];
         languagesStrings[0] = systemDefinedString;
         languagesCodes[0] = systemDefinedCode;
-        for (int i = 1; i < languages.size(); i++) {
-            languagesStrings[i] = languages.get(i).getName();
-            languagesCodes[i] = languages.get(i).getCode();
+        int languagesPosition = 1;
+        for (int i = 0; i < languages.size(); i++) {
+            languagesStrings[languagesPosition] = languages.get(i).getName();
+            languagesCodes[languagesPosition] = languages.get(i).getCode();
+            languagesPosition++;
         }
         listPreference.setEntries(languagesStrings);
         listPreference.setEntryValues(languagesCodes);


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2335 

### :tophat: What is the goal?

List of languages not properly working
-I only detect one bug, the first language is not added in the languages list.

### :memo: How is it being implemented?

The first language (0 position) was ignored, i added it into language list.

### :boom: How can it be tested?

 **Use case 1:** Login and move to settings with a phone with English language as default, you should see system default, and english too.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-