### PR TITLE
update the push period to the minimun

### DIFF
--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -19,7 +19,7 @@
     <string name="pref_cat_server" translatable="false">pref_cat_server</string>
     <item name="language_code" translatable="false" type="string">language_code</item>
 
-    <string name="PUSH_PERIOD" translatable="false">10</string>
+    <string name="PUSH_PERIOD" translatable="false">60</string>
 
     <string name="font_size_system" translatable="false">system</string>
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2340 

### :tophat: What is the goal?

Check the alarm workflow

### :memo: How is it being implemented?

I change the push period to 60 secs, the minimun allowed by android for the repeating alarms in api>19

I have checked the alarm workflw:

our alarm (with 10 seconds) runs every minute.
I tested using 120 secs and checked that it runs every 2 minutes (works as expected).

All this periods are not exact:

about <1 sec converting one voucher
about 1 sec for ONE quarantine
about 10 sec for push one voucher
(more info in the issue)

I created a diagram:
![untitled diagram](https://user-images.githubusercontent.com/5302538/49541154-3ae97880-f8d2-11e8-841e-02454a0340c7.png)


### :boom: How can it be tested?

Run the app an check if the push is pushed every 60 secs

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
