### PR TITLE
Download current language terms first and then the rest in async way

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/usecase/DownloadLanguageTranslationUseCase.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/usecase/DownloadLanguageTranslationUseCase.java
@@ -19,15 +19,15 @@ public class DownloadLanguageTranslationUseCase implements UseCase {
         this.credentialsReader = credentialsReader;
     }
 
-    public void downloadAsync(IAsyncExecutor mAsyncExecutor) throws Exception {
+    public void downloadAsync(IAsyncExecutor mAsyncExecutor) {
         mAsyncExecutor.run(this);
     }
 
-    public void download() throws Exception {
+    public void download(String languageCode) throws Exception {
 
         LanguageDownloader downloader = LanguageFactory.getLanguageDownloader(getClient(),
                 connectivity);
-        downloader.start();
+        downloader.start(languageCode);
 
     }
 
@@ -40,7 +40,7 @@ public class DownloadLanguageTranslationUseCase implements UseCase {
     @Override
     public void run() {
         try {
-            download();
+            download("");
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SplashActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SplashActivityStrategy.java
@@ -17,24 +17,20 @@ import org.eyeseetea.malariacare.data.authentication.CredentialsReader;
 import org.eyeseetea.malariacare.data.database.datasources.AuthDataSource;
 import org.eyeseetea.malariacare.data.database.datasources.SurveyLocalDataSource;
 import org.eyeseetea.malariacare.data.database.datasources.ValueLocalDataSource;
-import org.eyeseetea.malariacare.data.authentication.CredentialsReader;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
+import org.eyeseetea.malariacare.domain.boundary.IConnectivityManager;
 import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
 import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IAuthRepository;
 import org.eyeseetea.malariacare.domain.boundary.repositories.ISurveyRepository;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IValueRepository;
 import org.eyeseetea.malariacare.domain.entity.Survey;
-import org.eyeseetea.malariacare.domain.boundary.IConnectivityManager;
+import org.eyeseetea.malariacare.domain.usecase.ClearAuthUseCase;
 import org.eyeseetea.malariacare.domain.usecase.DownloadLanguageTranslationUseCase;
 import org.eyeseetea.malariacare.domain.usecase.SaveSurveyFromIntentUseCase;
-import org.eyeseetea.malariacare.domain.usecase.ClearAuthUseCase;
 import org.eyeseetea.malariacare.network.factory.NetworkManagerFactory;
 import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
 import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
-import org.eyeseetea.malariacare.domain.boundary.IConnectivityManager;
-import org.eyeseetea.malariacare.domain.usecase.DownloadLanguageTranslationUseCase;
-import org.eyeseetea.malariacare.network.factory.NetworkManagerFactory;
 
 public class SplashActivityStrategy extends ASplashActivityStrategy {
     public static final String INTENT_JSON_EXTRA_KEY = "ConnectVoucher";
@@ -140,10 +136,13 @@ public class SplashActivityStrategy extends ASplashActivityStrategy {
                 CredentialsReader credentialsReader = CredentialsReader.getInstance();
                 IConnectivityManager connectivity = NetworkManagerFactory.getConnectivityManager(
                         activity);
-                DownloadLanguageTranslationUseCase downloader =
+                DownloadLanguageTranslationUseCase useCase =
                         new DownloadLanguageTranslationUseCase(credentialsReader, connectivity);
 
-                downloader.download();
+                String currentLanguage = PreferencesState.getInstance().getCurrentLocale();
+
+                useCase.download(currentLanguage);
+                useCase.downloadAsync(new AsyncExecutor());
             }
         } catch (Exception e) {
             Log.e(TAG, "Unable to download Languages From Server" + e.getMessage());


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2352 
* **Related pull-requests:** 

### :tophat: What is the goal?

Optimize the time of splash activity is showing until navigate to the login activity

###   :gear: branches 
**app**:
       Origin: feature-optimize_the_download_of_languages_time_in_splash_activity Target: v1.4_connect

### :memo: How is it being implemented?

I added a language parameter to DownloadLanguageTranslationUseCase and first download terms of the current language and then download rest languages terms in an async way.

**Note: According to tests on my emulator, the navigation from splash activity to login activity is reduced over 10-15 seg approximately. For poor connections, the improvement can be bigger.**
The architecture corresponds to this process has bad practices, I have created a new issue to refactor in the future. https://github.com/EyeSeeTea/pictureapp/issues/2360

### :boom: How can it be tested?

 **Use case 1:** Remove current app, open Logcat and execute. Read traces and confirm that during splash activity visualization only downloads current language and when to navigate to login activity in an async way the rest of languages terms is downloading.

### :floppy_disk: Requires DB migration?

- [ ] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [x] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots