### PR TITLE
Fix crash on splash for android less than 8 versions

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SplashActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SplashActivityStrategy.java
@@ -46,6 +46,7 @@ public class SplashActivityStrategy extends ASplashActivityStrategy {
     public static final String INTENT_JSON_EXTRA_KEY = "ConnectVoucher";
     private Activity activity;
     private CustomTextView progressTextView;
+    private IMainExecutor mainExecutor;
 
     public interface Callback {
         void onSuccess();
@@ -54,6 +55,7 @@ public class SplashActivityStrategy extends ASplashActivityStrategy {
     public SplashActivityStrategy(Activity mActivity) {
         super(mActivity);
         this.activity = mActivity;
+        this.mainExecutor = new UIThreadExecutor();
         if(BuildConfig.translations) {
             PreferencesState.getInstance().loadsLanguageInActivity();
         }
@@ -225,7 +227,12 @@ public class SplashActivityStrategy extends ASplashActivityStrategy {
     }
 
     @Override
-    public void showProgressMessage(@StringRes int resourceId) {
-        progressTextView.setTextTranslation(resourceId);
+    public void showProgressMessage(@StringRes final int resourceId) {
+        mainExecutor.run(new Runnable() {
+            @Override
+            public void run() {
+                progressTextView.setTextTranslation(resourceId);
+            }
+        });
     }
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2372 
* **Related pull-requests:** 

### :tophat: What is the goal?

Fix crash on splash for android previous to 8 versions

###   :gear: branches 
**app**:
       Origin: bug-app_crash_on_splash_in_less_than_8_versions: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

- I have created an instance of MainExecutor and set progress text using this one.

### :boom: How can it be tested?

**Use Case 1**:  open app from Android previous to 8 version and the app should navigate from splash to login activity sucessfully

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [] Yeap, here you have some screenshots