### PR TITLE
Fix show multiple soft login dialogs

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/BaseActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/BaseActivityStrategy.java
@@ -63,6 +63,7 @@ public class BaseActivityStrategy extends ABaseActivityStrategy {
     private static final int MENU_ITEM_LOGOUT = 99;
     private static final int MENU_ITEM_LOGOUT_ORDER = 106;
     private static final int SETTINGS_LOGOUT = 107;
+    private static final String SOFT_LOGIN_DIALOG_TAG = "soft_login_dialog";
 
     LogoutUseCase mLogoutUseCase;
 
@@ -163,11 +164,19 @@ public class BaseActivityStrategy extends ABaseActivityStrategy {
     }
 
     private void showSoftLoginDialog() {
+
         if (!currentUser.isDemo()) {
             FragmentManager fm = mBaseActivity.getSupportFragmentManager();
 
+            SoftLoginDialogFragment prev =
+                    (SoftLoginDialogFragment)fm.findFragmentByTag(SOFT_LOGIN_DIALOG_TAG);
+
+            if (prev != null) {
+                return;
+            }
+
             SoftLoginDialogFragment softLoginDialogFragment = SoftLoginDialogFragment.newInstance();
-            softLoginDialogFragment.show(fm, "soft_login");
+            softLoginDialogFragment.show(fm, SOFT_LOGIN_DIALOG_TAG);
 
             mBaseActivity.getSupportFragmentManager().executePendingTransactions();
             softLoginDialogFragment.getDialog().setOnDismissListener(


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2374 
* **Related pull-requests:** 

### :tophat: What is the goal?

Avoid multiple soft-login dialogs overlapping

###   :gear: branches 
**app**:
       Origin: bug-avoid_show_multiple_soft_login_dialogs:  Target: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

- From dashboard activity, I check if exists a previous soft login and on this case, I don`t show a new soft login

### :boom: How can it be tested?

**Use Case 1**:  Open app and with a phone without lock pattern turn off and turn on the screen several times, then only one soft login dialog should be visible

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [] Yeap, here you have some screenshots