### PR TITLE
Manage server available exception on soft login

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/usecase/SoftLoginUseCase.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/usecase/SoftLoginUseCase.java
@@ -10,6 +10,7 @@ import org.eyeseetea.malariacare.domain.entity.Credentials;
 import org.eyeseetea.malariacare.domain.entity.InvalidLoginAttempts;
 import org.eyeseetea.malariacare.domain.entity.UserAccount;
 import org.eyeseetea.malariacare.domain.exception.ActionNotAllowed;
+import org.eyeseetea.malariacare.domain.exception.AvailableApiException;
 import org.eyeseetea.malariacare.domain.exception.InvalidCredentialsException;
 
 public class SoftLoginUseCase implements UseCase {
@@ -68,6 +69,8 @@ public class SoftLoginUseCase implements UseCase {
                             public void onError(Throwable throwable) {
                                 if (throwable instanceof InvalidCredentialsException) {
                                     notifyInvalidPassword();
+                                } else if (throwable instanceof AvailableApiException) {
+                                    notifyServerNotAvailable(throwable.getMessage());
                                 } else {
                                     notifyNetworkError();
                                 }
@@ -146,6 +149,15 @@ public class SoftLoginUseCase implements UseCase {
         });
     }
 
+    public void notifyServerNotAvailable(final String message) {
+        mainExecutor.run(new Runnable() {
+            @Override
+            public void run() {
+                mCallback.onServerNotAvailable(message);
+            }
+        });
+    }
+
     public interface Callback {
         void onSoftLoginSuccess();
 
@@ -154,5 +166,7 @@ public class SoftLoginUseCase implements UseCase {
         void onNetworkError();
 
         void onMaxInvalidLoginAttemptsError(long enableLoginTime);
+
+        void onServerNotAvailable(String message);
     }
 }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/presentation/presenters/SoftLoginPresenter.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/presentation/presenters/SoftLoginPresenter.java
@@ -152,6 +152,14 @@ public class SoftLoginPresenter {
                 disableLoginActionUntilEnableLoginTime(enableLoginTime);
 
             }
+
+            @Override
+            public void onServerNotAvailable(String message) {
+                if (view != null) {
+                    view.hideProgress();
+                    view.showServerNotAvailable(message);
+                }
+            }
         });
     }
 
@@ -304,5 +312,7 @@ public class SoftLoginPresenter {
         void showLogoutError();
 
         void showInvalidAuthFromExternalApp();
+
+        void showServerNotAvailable(String message);
     }
 }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/views/SoftLoginDialogFragment.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/views/SoftLoginDialogFragment.java
@@ -182,8 +182,18 @@ public class SoftLoginDialogFragment extends DialogFragment implements SoftLogin
         showError(R.string.different_user_error);
     }
 
+    @Override
+    public void showServerNotAvailable(String message) {
+        showError(message);
+    }
+
     public void showError(int message) {
         Toast.makeText(this.getActivity(), translate(message),
+                Toast.LENGTH_LONG).show();
+    }
+
+    public void showError(String message) {
+        Toast.makeText(this.getActivity(), message,
                 Toast.LENGTH_LONG).show();
     }
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2381 
* **Related pull-requests:** 

### :tophat: What is the goal?

Manager server available error from soft login

###   :gear: branches 
**app**:
       Origin: feature-manage_available_api_error_on_soft_login:  Target: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

- From soft login use case manager if the error is AvailableApiException then notify this error until fragment and show a toast

### :boom: How can it be tested?

**Use Case 1**:  Modify eReferralsAPIClient and method getIfIsApiAvailable for returns always AvailableApiException, then a message from api/available response should be shown

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [] Yeap, here you have some screenshots