### PR TITLE
Disable login button until pin has a value

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/presentation/presenters/SoftLoginPresenter.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/presentation/presenters/SoftLoginPresenter.java
@@ -24,7 +24,11 @@ public class SoftLoginPresenter {
     private final CheckAuthUseCase checkExternalAuthUseCase;
     private final SaveAuthUseCase saveAuthUseCase;
 
-    boolean showingAdvancedOptions = false;
+    private boolean showingAdvancedOptions = false;
+
+    private boolean isLoginDisabledByMaxInvalidLoginAttempts = false;
+    private boolean isLoginDisabledByEmptyPin = false;
+
 
     public SoftLoginPresenter(GetUserUserAccountUseCase getUserUserAccountUseCase,
             SoftLoginUseCase softLoginUseCase,
@@ -50,6 +54,7 @@ public class SoftLoginPresenter {
         this.view.hideProgress();
         this.view.hideAdvancedOptions();
 
+        disableLoginAction();
         loadCurrentUser();
         verifySoftLoginFromOtherApp();
     }
@@ -193,13 +198,31 @@ public class SoftLoginPresenter {
         }, settings);
     }
 
+    public void onPinChanged(String pin) {
+        if (pin == null || pin.isEmpty()) {
+            isLoginDisabledByEmptyPin = true;
+            disableLoginAction();
+        } else {
+            isLoginDisabledByEmptyPin = false;
+
+            if (isLoginDisabledByMaxInvalidLoginAttempts == false) {
+                enableLoginAction();
+            }
+        }
+    }
+
     private void disableLoginActionUntilEnableLoginTime(final long enableLoginTime) {
+        disableLoginAction();
+        isLoginDisabledByMaxInvalidLoginAttempts = true;
+
+        verifyEnableLogin(enableLoginTime);
+    }
+
+    private void disableLoginAction() {
         if (view != null) {
             view.hideProgress();
             view.disableLoginAction();
         }
-
-        verifyEnableLogin(enableLoginTime);
     }
 
     private void verifyEnableLogin(final long enableLoginTime) {
@@ -207,14 +230,21 @@ public class SoftLoginPresenter {
             @Override
             public void run() {
                 if (System.currentTimeMillis() >= enableLoginTime) {
-                    if (view != null) {
-                        view.enableLoginAction();
-                    }
+                    isLoginDisabledByMaxInvalidLoginAttempts = false;
+
+                    enableLoginAction();
                 } else {
                     verifyEnableLogin(enableLoginTime);
                 }
             }
         }, 1000);
+    }
+
+    private void enableLoginAction() {
+        if (view != null && !isLoginDisabledByEmptyPin &&
+                !isLoginDisabledByMaxInvalidLoginAttempts) {
+            view.enableLoginAction();
+        }
     }
 
     private void loadCurrentUser() {

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/views/SoftLoginDialogFragment.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/views/SoftLoginDialogFragment.java
@@ -5,6 +5,8 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.v4.app.DialogFragment;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -100,6 +102,23 @@ public class SoftLoginDialogFragment extends DialogFragment implements SoftLogin
         userNameEditText = view.findViewById(R.id.edittext_username);
         userNameEditText.setEnabled(false);
         passwordEditText = view.findViewById(R.id.edittext_password);
+
+        passwordEditText.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                presenter.onPinChanged(s.toString());
+            }
+        });
     }
 
     private void initializePresenter() {


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2375 
* **Related pull-requests:** 

### :tophat: What is the goal?

Disable login button until pin has value

Manager server available error from soft login

###   :gear: branches 
**app**:
       Origin: bug-disble_login_until_pin_has_value:  Target: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

- I have added this logic to presenter

### :boom: How can it be tested?

**Use Case 1**:  when soft login appears should have login button disabled
**Use Case 2**:  when user type pin login button should be enabled
**Use Case 3**:  when user remove pin login button should be disabled
**Use Case 4**:  when user insert 3 times wrong pin and login is disabled if user type pin on this period login button should maintain disabled until is enabled after 30 seg
**Use Case 5**:  when user insert 3 times wrong pin and login is disabled if user remove pin after 30seg the login button should not be enabled because the pin is empty

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [] Yeap, here you have some screenshots