### PR TITLE
Fix intent in

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/usecase/CheckAuthUseCase.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/usecase/CheckAuthUseCase.java
@@ -11,8 +11,11 @@ public class CheckAuthUseCase implements UseCase {
 
     public interface Callback {
         void onEmptyCredentials();
+
         void onEmptyAuth();
+
         void onValidAuth();
+
         void onInValidAuth();
 
     }
@@ -41,34 +44,29 @@ public class CheckAuthUseCase implements UseCase {
 
     @Override
     public void run() {
-        mMainExecutor.run(new Runnable() {
-            @Override
-            public void run() {
-                Auth auth = mAuthRepository.getAuth();
+        Auth auth = mAuthRepository.getAuth();
 
-                if(auth==null){
-                    //auth voucher from other app doesn't exist.
-                    return;
-                }
+        if (auth == null) {
+            //auth voucher from other app doesn't exist.
+            return;
+        }
 
-                Credentials credentials = mCredentialsRepository.getLastValidCredentials();
-                if(!hasCredentials(credentials)){
-                    notifyEmptyCredentials();
-                    return;
-                }
+        Credentials credentials = mCredentialsRepository.getLastValidCredentials();
+        if (!hasCredentials(credentials)) {
+            notifyEmptyCredentials();
+            return;
+        }
 
-                if(auth.hasAuth()){
-                    if(isValidUserAndPassword(credentials, auth)){
-                        notifyValidAuth();
-                        return;
-                    }else {
-                        notifyInValidAuth();
-                        return;
-                    }
-                }
-                notifyEmptyAuth();
+        if (auth.hasAuth()) {
+            if (isValidUserAndPassword(credentials, auth)) {
+                notifyValidAuth();
+                return;
+            } else {
+                notifyInValidAuth();
+                return;
             }
-        });
+        }
+        notifyEmptyAuth();
     }
 
     private boolean hasCredentials(Credentials credentials) {
@@ -115,7 +113,6 @@ public class CheckAuthUseCase implements UseCase {
             }
         });
     }
-
 
 
 }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/usecase/CheckAuthUseCase.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/usecase/CheckAuthUseCase.java
@@ -53,20 +53,20 @@ public class CheckAuthUseCase implements UseCase {
 
                 Credentials credentials = mCredentialsRepository.getLastValidCredentials();
                 if(!hasCredentials(credentials)){
-                    mCallback.onEmptyCredentials();
+                    notifyEmptyCredentials();
                     return;
                 }
 
                 if(auth.hasAuth()){
                     if(isValidUserAndPassword(credentials, auth)){
-                        mCallback.onValidAuth();
+                        notifyValidAuth();
                         return;
                     }else {
-                        mCallback.onInValidAuth();
+                        notifyInValidAuth();
                         return;
                     }
                 }
-                mCallback.onEmptyAuth();
+                notifyEmptyAuth();
             }
         });
     }
@@ -79,4 +79,43 @@ public class CheckAuthUseCase implements UseCase {
         return auth.getUserName().equals(credentials.getUsername())
                 && auth.getPassword().equals(credentials.getPassword());
     }
+
+    private void notifyEmptyAuth() {
+        mMainExecutor.run(new Runnable() {
+            @Override
+            public void run() {
+                mCallback.onEmptyAuth();
+            }
+        });
+    }
+
+    private void notifyInValidAuth() {
+        mMainExecutor.run(new Runnable() {
+            @Override
+            public void run() {
+                mCallback.onInValidAuth();
+            }
+        });
+    }
+
+    private void notifyValidAuth() {
+        mMainExecutor.run(new Runnable() {
+            @Override
+            public void run() {
+                mCallback.onValidAuth();
+            }
+        });
+    }
+
+    private void notifyEmptyCredentials() {
+        mMainExecutor.run(new Runnable() {
+            @Override
+            public void run() {
+                mCallback.onEmptyCredentials();
+            }
+        });
+    }
+
+
+
 }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SplashActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SplashActivityStrategy.java
@@ -61,9 +61,14 @@ public class SplashActivityStrategy extends ASplashActivityStrategy {
 
     @Override
     public void setContentView() {
-        activity.setContentView(R.layout.activity_splash);
+        try {
+            activity.setContentView(R.layout.activity_splash);
 
-        progressTextView = activity.findViewById(R.id.progress_text);
+            progressTextView = activity.findViewById(R.id.progress_text);
+        } catch (Exception e) {
+            Log.d("", "");
+        }
+
     }
 
     public void init(final SplashScreenActivity.Callback callback) {

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SplashActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SplashActivityStrategy.java
@@ -61,14 +61,9 @@ public class SplashActivityStrategy extends ASplashActivityStrategy {
 
     @Override
     public void setContentView() {
-        try {
-            activity.setContentView(R.layout.activity_splash);
+        activity.setContentView(R.layout.activity_splash);
 
-            progressTextView = activity.findViewById(R.id.progress_text);
-        } catch (Exception e) {
-            Log.d("", "");
-        }
-
+        progressTextView = activity.findViewById(R.id.progress_text);
     }
 
     public void init(final SplashScreenActivity.Callback callback) {


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2384  
* **Related pull-requests:** 

### :tophat: What is the goal?

Solve intent in because does not work

Manager server available error from soft login

###   :gear: branches 
**app**:
       Origin: bug-intent_in_not_working:  Target: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

Fix async operations in CheckAuthUseCase and SaveSurveyFromIntentUseCase
Use case must to realize io operations (database, disk and network) in async way and notify with callbacks in the main thread

### :boom: How can it be tested?

#### Feature: Intent in
To test this scenario you can use an external app to create new survey
##### UseCase: Login
- [x] **Scenario 1:** 
Install connect the first time o log out current installation
Send an intent from Connect2ConnectExampleApp to connect, the app should navigate to login activity an error message should be shown because this feature only works with soft login.

##### UseCase: Soft Login
- [x] **Scenario 1:** 
Send an intent with empty auth from Connect2ConnectExampleApp to connect, the app should navigate to the dashboard and show Soft login Dialog. After Soft login, the app should navigate to the new survey.
- [x] **Scenario 2:** 
Send an intent with a wrong auth from Connect2ConnectExampleApp to connect, the app should navigate to the dashboard and show Soft login Dialog with an error toast.
- [x] **Scenario 3:** 
Send an intent with a valid auth from Connect2ConnectExampleApp to connect, the app should navigate to login dashboard and does not show soft login and the app should navigate to a new survey.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [] Yeap, here you have some screenshots