### PR TITLE
mark pull as required when survey is open

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/BaseActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/BaseActivityStrategy.java
@@ -41,6 +41,7 @@ import org.eyeseetea.malariacare.domain.usecase.GetAppInfoUseCase;
 import org.eyeseetea.malariacare.domain.usecase.GetSettingsUseCase;
 import org.eyeseetea.malariacare.domain.usecase.GetUserUserAccountUseCase;
 import org.eyeseetea.malariacare.domain.usecase.LogoutUseCase;
+import org.eyeseetea.malariacare.domain.usecase.SaveSettingsUseCase;
 import org.eyeseetea.malariacare.factories.AuthenticationFactoryStrategy;
 import org.eyeseetea.malariacare.factories.SettingsFactory;
 import org.eyeseetea.malariacare.fragments.ReviewFragment;
@@ -191,7 +192,30 @@ public class BaseActivityStrategy extends ABaseActivityStrategy {
             FragmentManager fm = mBaseActivity.getSupportFragmentManager();
             PullDialogFragment pullDialogFragment = PullDialogFragment.newInstance();
             pullDialogFragment.show(fm, "pull");
+        } else {
+            markPullAsRequired();
         }
+    }
+
+    private void markPullAsRequired() {
+        GetSettingsUseCase getSettingsUseCase =
+                new SettingsFactory().getSettingsUseCase(mBaseActivity);
+        final SaveSettingsUseCase saveSettingsUseCase =
+                new SettingsFactory().saveSettingsUseCase(mBaseActivity);
+
+        getSettingsUseCase.execute(new GetSettingsUseCase.Callback() {
+            @Override
+            public void onSuccess(Settings settings) {
+                settings.changePullRequired(true);
+
+                saveSettingsUseCase.execute(new SaveSettingsUseCase.Callback() {
+                    @Override
+                    public void onSuccess() {
+                        Log.d(TAG, "Pull marked as required");
+                    }
+                }, settings);
+            }
+        });
     }
 
     private boolean isSurveyOpen() {


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2383 
* **Related pull-requests:** 

### :tophat: What is the goal?

If the pull is necessary but a survey is opened, the pull should be marked as required.

###   :gear: branches 
**app**:
       Origin: bug-when_survey_is_open_required_pull_should_be_saved v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

- I survey is opened I have use getSettingsUseCase and SaveSettingsUsecase to mark pull as required

### :boom: How can it be tested?

First prepare the code to hacking 209 error and pull:
- go to eReferralsAPIClient and in the condition success on line 139 replace this:
wsClientCallBack.onSuccess(response.body());
for
            ConfigFileObsoleteException configFileObsoleteException =
                    new ConfigFileObsoleteException();
            wsClientCallBack.onSuccess(response.body());
            wsClientCallBack.onError(configFileObsoleteException); 
To return always 209 case on every push

- In hasToUpdateMetadata method in MetadataConfigurationDBImporter class modify line 87 - to return true: } else if (true) {
- in PullDialogFragment modify pullSuccess method to dimis after delay:
@override
public void pullSuccess() {
Handler handler = new Handler();
handler.postDelayed(new Runnable() {
@override
public void run() {
getDialog().dismiss();
}
}, 5000);
}

#### Feature: 209 in push
#### UseCase: Push
- [ ] **Scenario 3:** create a new survey and open another new survey before push starts when push starts will throw ConfigFileObsoleteException but will not be released because It's saved that pull is required. Close the survey and when the survey is closed should show pull dialog from the dashboard.

#### Feature: Launch pull if from offline connection to online connection survey can not add surveys
- [ ] **Scenario 3:** create a new survey when push starts the execution stops in push response breakpoint, change while connection to off, then pull will not be released because It's saved that pull is required, Close the survey and when the survey is closed should show network error problem, then turn connection on and pull should be launched.

### :floppy_disk: Requires DB migration?

- [ ] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [x] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots