### PR TITLE
does not verify languages on splash if exists logged user

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SplashActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SplashActivityStrategy.java
@@ -47,6 +47,8 @@ public class SplashActivityStrategy extends ASplashActivityStrategy {
     private Activity activity;
     private CustomTextView progressTextView;
 
+    private UserAccount currentUserAccount;
+
     public interface Callback {
         void onSuccess();
     }
@@ -57,6 +59,8 @@ public class SplashActivityStrategy extends ASplashActivityStrategy {
         if(BuildConfig.translations) {
             PreferencesState.getInstance().loadsLanguageInActivity();
         }
+
+        loadCurrentUser();
     }
 
     @Override
@@ -107,6 +111,18 @@ public class SplashActivityStrategy extends ASplashActivityStrategy {
 
     }
 
+    private void loadCurrentUser() {
+        GetUserUserAccountUseCase getUserUserAccountUseCase =
+                new AuthenticationFactoryStrategy().getUserAccountUseCase();
+
+        getUserUserAccountUseCase.execute(new GetUserUserAccountUseCase.Callback() {
+            @Override
+            public void onGetUserAccount(UserAccount userAccount) {
+                currentUserAccount = userAccount;
+            }
+        });
+    }
+
     private void clearAuth(final SplashScreenActivity.Callback callback) {
         ClearAuthUseCase clearAuthUseCase = new ClearAuthUseCase(new UIThreadExecutor(), new AsyncExecutor(), new AuthDataSource(activity.getBaseContext()));
         clearAuthUseCase.execute(new ClearAuthUseCase.Callback() {
@@ -119,23 +135,15 @@ public class SplashActivityStrategy extends ASplashActivityStrategy {
 
     @Override
     public void finishAndGo() {
-        GetUserUserAccountUseCase getUserUserAccountUseCase =
-                new AuthenticationFactoryStrategy().getUserAccountUseCase();
-
-        getUserUserAccountUseCase.execute(new GetUserUserAccountUseCase.Callback() {
-            @Override
-            public void onGetUserAccount(UserAccount userAccount) {
-                if (userAccount == null) {
-                    SplashActivityStrategy.super.finishAndGo(LoginActivity.class);
-                } else {
-                    if (!userAccount.isDemo()) {
-                        markSoftLoginRequired();
-                    }
-
-                    SplashActivityStrategy.super.finishAndGo(DashboardActivity.class);
-                }
+        if (currentUserAccount == null) {
+            SplashActivityStrategy.super.finishAndGo(LoginActivity.class);
+        } else {
+            if (!currentUserAccount.isDemo()) {
+                markSoftLoginRequired();
             }
-        });
+
+            SplashActivityStrategy.super.finishAndGo(DashboardActivity.class);
+        }
     }
 
     private void markSoftLoginRequired() {
@@ -187,7 +195,7 @@ public class SplashActivityStrategy extends ASplashActivityStrategy {
     @Override
     public void downloadLanguagesFromServer() {
         try {
-            if (BuildConfig.downloadLanguagesFromServer) {
+            if (BuildConfig.downloadLanguagesFromServer && currentUserAccount == null) {
                 Log.i(TAG, "Starting to download Languages From Server");
                 CredentialsReader credentialsReader = CredentialsReader.getInstance();
                 IConnectivityManager connectivity = NetworkManagerFactory.getConnectivityManager(


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2385
* **Related pull-requests:** 

### :tophat: What is the goal?
Does not verify languages on splash if exists logged user

###   :gear: branches 
**app**:
       Origin: bug-does_not_verify_languages_on_splash_if_exists_logged_user v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

- From splash when languages are downloaded previously verify if exists logged user

### :boom: How can it be tested?

#### feature start app:
- [ ] **Scenario 1:** launch the app without previously logged user splash should verify languages and download if required

- [ ] **Scenario 2:** launch the app with previously logged user splash should not verify languages and download if required

### :floppy_disk: Requires DB migration?

- [ ] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [x] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots