### PR TITLE
Feature deactivate refresh button with countdown

### DIFF
--- a/app/src/ereferrals/res/drawable/refresh_web_view_background.xml
+++ b/app/src/ereferrals/res/drawable/refresh_web_view_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/create_button_background" android:state_enabled="true" />
+    <item android:color="@color/disabled_color" android:state_enabled="false" />
+</selector>

--- a/app/src/ereferrals/res/layout/fragment_web_view.xml
+++ b/app/src/ereferrals/res/layout/fragment_web_view.xml
@@ -25,26 +25,38 @@
         android:layout_margin="30dp"
         android:visibility="gone"/>
 
+
     <FrameLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
         android:layout_alignParentBottom="true">
 
-        <android.support.design.widget.FloatingActionButton xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:app="http://schemas.android.com/apk/res-auto"
+        <android.support.design.widget.FloatingActionButton
             android:id="@+id/refresh_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="32dp"
             android:src="@drawable/ic_refresh_webview"
-            app:backgroundTint="@color/create_button_background"
-            android:layout_alignParentRight="true"
-            android:layout_gravity="center_horizontal|right"
-            android:layout_marginRight="16dp"
+            app:backgroundTint="@drawable/refresh_web_view_background"
             android:onClick="newSurvey"
             app:fabSize="normal"
-            app:layout_anchorGravity="bottom|right|end" />
+            android:layout_marginBottom="32dp"
+            android:layout_marginRight="16dp"
+            app:layout_anchorGravity="bottom|right|end"
+            android:layout_gravity="center_horizontal|right" />
+
+        <TextView
+            android:id="@+id/countdown_text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="60"
+            android:elevation="16dp"
+            android:textColor="@android:color/white"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:layout_marginBottom="16dp"
+            android:layout_marginRight="8dp"
+            android:visibility="gone"/>
     </FrameLayout>
 
 </RelativeLayout>

--- a/app/src/ereferrals/res/values/colors.xml
+++ b/app/src/ereferrals/res/values/colors.xml
@@ -25,6 +25,8 @@
     <color name="question_title">@color/text_first_color</color>
     <color name="question_subtitle">@color/medium_light_purple</color>
 
+    <color name="disabled_color">#80B5B5B5</color>
+
     <color name="pageIndicator_completed">@color/dark_purple</color>
     <color name="pageIndicator_pending">@color/light_purple</color>
     <color name="monitor_background">@color/white</color>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2393 
* **Related pull-requests:** 

### :tophat: What is the goal?
Disable 60 seconds the webview refresh after the click and to add a countdown text

###   :gear: branches 
**app**:
       Origin: feature-deactivate_refresh_button_with_countdown v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

- I have added a text view over float action button and with a handler set the countdown.

### :boom: How can it be tested?

- [x] **Use case 1:** Click on refresh button of web view, this one should be disabled and the countdown should appear. After the count down the refresh button should be enabled again,

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots