### PR TITLE
Verify languages in background if logged user exists

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SplashActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SplashActivityStrategy.java
@@ -197,7 +197,7 @@ public class SplashActivityStrategy extends ASplashActivityStrategy {
     @Override
     public void downloadLanguagesFromServer() {
         try {
-            if (BuildConfig.downloadLanguagesFromServer && currentUserAccount == null) {
+            if (BuildConfig.downloadLanguagesFromServer) {
                 Log.i(TAG, "Starting to download Languages From Server");
                 CredentialsReader credentialsReader = CredentialsReader.getInstance();
                 IConnectivityManager connectivity = NetworkManagerFactory.getConnectivityManager(
@@ -205,9 +205,12 @@ public class SplashActivityStrategy extends ASplashActivityStrategy {
                 DownloadLanguageTranslationUseCase useCase =
                         new DownloadLanguageTranslationUseCase(credentialsReader, connectivity);
 
-                String currentLanguage = PreferencesState.getInstance().getCurrentLocale();
+                if (currentUserAccount == null) {
+                    String currentLanguage = PreferencesState.getInstance().getCurrentLocale();
 
-                useCase.download(currentLanguage);
+                    useCase.download(currentLanguage);
+                }
+
                 useCase.downloadAsync(new AsyncExecutor());
             }
         } catch (Exception e) {


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2395  
* **Related pull-requests:** 

### :tophat: What is the goal?
If the logged user exists verify languages only in background

###   :gear: branches 
**app**:
       Origin: feature-verify_languages_always_in_background_if_user_exists v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

- If a logged user does not exist current language is downloaded in sync way and rest of languages in an async way but if user exist all languages are verified in an async way

### :boom: How can it be tested?

- [x] **Use case 1:** The first time the current language terms are downloaded in sync way from splash and the rest in an async way
- [x] **Use case 2:** the next times all language terms are downloaded in an async way from splash

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots