### PR TITLE
Maintenance question disabled feature

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -381,10 +381,10 @@ dependencies {
     compile "com.squareup:javapoet:${libs.javapoetVersion}"
 
     //DBFlow
-    apt "com.github.Raizlabs.DBFlow:dbflow-processor:${libs.dbFlowVersion}"
-    compile "com.github.Raizlabs.DBFlow:dbflow:${libs.dbFlowVersion}"
-    compile "com.github.Raizlabs.DBFlow:dbflow-core:${libs.dbFlowVersion}"
-    compile "com.github.Raizlabs.DBFlow:dbflow-sqlcipher:${libs.dbFlowVersion}"
+    apt "com.github.agrosner.dbflow:dbflow-processor:${libs.dbFlowVersion}"
+    compile "com.github.agrosner.dbflow:dbflow:${libs.dbFlowVersion}"
+    compile "com.github.agrosner.dbflow:dbflow-core:${libs.dbFlowVersion}"
+    compile "com.github.agrosner.dbflow:dbflow-sqlcipher:${libs.dbFlowVersion}"
     compile(project(path: ':bugshaker')) {
         exclude group: "com.google.android.gms"
     }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationApiClient.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationApiClient.java
@@ -573,6 +573,7 @@ public class MetadataConfigurationApiClient implements IMetadataConfigurationDat
                     .visibility(getVisibilityFrom(apiQuestion))
                     .options(convertToDomainOptionsFrom(apiQuestion.options, apiQuestion))
                     .compulsory(apiQuestion.compulsory)
+                    .disabled(apiQuestion.disabled)
                     .rules(convertToDomainRules(apiQuestion.rules))
                     .regExp(apiQuestion.validationRegex)
                     .regExpError(apiQuestion.validationPoTerm)

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/model/CountryMetadataApi.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/model/CountryMetadataApi.java
@@ -65,6 +65,9 @@ public class CountryMetadataApi {
         @JsonProperty("mandatory")
         public boolean compulsory = true;
 
+        @JsonProperty("disabled")
+        public boolean disabled = false;
+
         @JsonProperty("options")
         public List<Option> options;
 

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/AppDatabase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/AppDatabase.java
@@ -31,7 +31,7 @@ import org.eyeseetea.malariacare.BuildConfig;
 
 public class AppDatabase {
     public static final String NAME = "EyeSeeTeaDB";
-    public static final int VERSION = 21;
+    public static final int VERSION = 22;
 
 
     // Aliases used for EyeSeeTea DB queries

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/migrations/Migration22QuestionDisabled.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/migrations/Migration22QuestionDisabled.java
@@ -1,0 +1,17 @@
+package org.eyeseetea.malariacare.data.database.migrations;
+
+import com.raizlabs.android.dbflow.annotation.Migration;
+import com.raizlabs.android.dbflow.sql.SQLiteType;
+import com.raizlabs.android.dbflow.sql.migration.AlterTableMigration;
+
+import org.eyeseetea.malariacare.data.database.AppDatabase;
+import org.eyeseetea.malariacare.data.database.model.QuestionDB;
+
+@Migration(version = 22, database = AppDatabase.class)
+public class Migration22QuestionDisabled extends AlterTableMigration<QuestionDB> {
+    public Migration22QuestionDisabled(
+            Class<QuestionDB> table) {
+        super(table);
+        addColumn(SQLiteType.INTEGER, "disabled");
+    }
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/model/QuestionDB.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/model/QuestionDB.java
@@ -188,6 +188,9 @@ public class QuestionDB extends BaseModel {
     @Column
     Integer compulsory;
 
+    @Column
+    boolean disabled;
+
     public List<OptionDB> getOptionDBS() {
         return optionDBS;
     }
@@ -735,6 +738,14 @@ public class QuestionDB extends BaseModel {
 
     public void setCompulsory(Integer compulsory) {
         this.compulsory = compulsory;
+    }
+
+    public Boolean isDisabled() {
+        return disabled;
+    }
+
+    public void setDisabled(boolean disabled) {
+        this.disabled = disabled;
     }
 
     public String getPath() {
@@ -2042,6 +2053,7 @@ public class QuestionDB extends BaseModel {
         result = 31 * result + (path != null ? path.hashCode() : 0);
         result = 31 * result + (total_questions != null ? total_questions.hashCode() : 0);
         result = 31 * result + (compulsory != null ? compulsory.hashCode() : 0);
+        result = 31 * result + (disabled ? 1 : 0);
         return result;
     }
 
@@ -2060,6 +2072,7 @@ public class QuestionDB extends BaseModel {
                 ", denominator_w=" + denominator_w +
                 ", id_header=" + id_header_fk +
                 ", id_answer=" + id_answer_fk +
+                ", disabled=" + disabled +
                 ", compulsory=" + compulsory +
                 ", output=" + output +
                 ", id_question_parent=" + id_question_parent +

--- a/app/src/main/java/org/eyeseetea/malariacare/data/mappers/QuestionConvertFromDomainVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/mappers/QuestionConvertFromDomainVisitor.java
@@ -44,6 +44,7 @@ public class QuestionConvertFromDomainVisitor implements
         dbModel.setForm_name(domainModel.getName());
         dbModel.setOutput(getOutFrom(domainModel.getType()));
         dbModel.setCompulsory(getCompulsoryFrom(domainModel.isCompulsory()));
+        dbModel.setDisabled(domainModel.isDisabled());
         dbModel.setAnswer(getAnswerDBFromDomain(domainModel));
         dbModel.setHeaderDB(getHeaderID(domainModel));
         dbModel.setTotalQuestions(1);

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Question.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Question.java
@@ -1,9 +1,9 @@
 package org.eyeseetea.malariacare.domain.entity;
 
 
-import org.eyeseetea.malariacare.domain.exception.RegExpValidationException;
-
 import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+
+import org.eyeseetea.malariacare.domain.exception.RegExpValidationException;
 
 import java.util.List;
 
@@ -15,6 +15,7 @@ public class Question {
     private PhoneFormat phoneFormat;
     private Type type;
     private boolean compulsory;
+    private boolean disabled;
     private List<Option> options;
     private Header header;
     private int index;
@@ -27,7 +28,7 @@ public class Question {
 
     public Question(long id, String code, String name, String uid,
             PhoneFormat phoneFormat, Type type, boolean compulsory,
-            List<Option> options, Header header, int index,
+            boolean disabled, List<Option> options, Header header, int index,
             Visibility visibility,
             List<Rule> rules, Value value, String regExp,
             String regExpError, String defaultValue) {
@@ -39,6 +40,7 @@ public class Question {
         this.phoneFormat = phoneFormat;
         this.type = required(type, "type is required");
         this.compulsory = compulsory;
+        this.disabled = disabled;
         this.options = options;
         this.header = header;
         this.index = index;
@@ -68,6 +70,10 @@ public class Question {
 
     public boolean isCompulsory() {
         return compulsory;
+    }
+
+    public boolean isDisabled() {
+        return disabled;
     }
 
     public List<Option> getOptions() {
@@ -229,6 +235,7 @@ public class Question {
         private String regExp;
         private String regExpError;
         private String defaultValue;
+        private boolean disabled;
 
         public Builder() {
         }
@@ -260,6 +267,11 @@ public class Question {
 
         public Builder compulsory(boolean val) {
             compulsory = val;
+            return this;
+        }
+
+        public Builder disabled(boolean val) {
+            disabled = val;
             return this;
         }
 
@@ -316,6 +328,7 @@ public class Question {
                     this.phoneFormat,
                     this.type,
                     this.compulsory,
+                    this.disabled,
                     this.options,
                     this.header,
                     this.index,

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/DynamicTabAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/DynamicTabAdapter.java
@@ -612,7 +612,13 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
             questionView.setHelpText(
                     translate(screenQuestionDB.getHelp_text()));
 
-            questionView.setEnabled(!readOnly && !screenQuestionDB.isDisabled());
+            boolean enabled = !readOnly && !screenQuestionDB.isDisabled();
+
+            questionView.setEnabled(enabled);
+
+            if (!enabled){
+                tableRow.setBackground(context.getResources().getDrawable(R.color.disabled_color));
+            }
 
             if (questionView instanceof IImageQuestionView) {
                 ((IImageQuestionView) questionView).setImage(

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/DynamicTabAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/DynamicTabAdapter.java
@@ -45,7 +45,6 @@ import android.widget.Spinner;
 import android.widget.Switch;
 import android.widget.TableLayout;
 import android.widget.TableRow;
-import android.widget.TextView;
 
 import org.eyeseetea.malariacare.BuildConfig;
 import org.eyeseetea.malariacare.DashboardActivity;
@@ -613,7 +612,7 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
             questionView.setHelpText(
                     translate(screenQuestionDB.getHelp_text()));
 
-            questionView.setEnabled(!readOnly);
+            questionView.setEnabled(!readOnly && !screenQuestionDB.isDisabled());
 
             if (questionView instanceof IImageQuestionView) {
                 ((IImageQuestionView) questionView).setImage(

--- a/app/src/main/res/layout/multi_question_tab_int_row.xml
+++ b/app/src/main/res/layout/multi_question_tab_int_row.xml
@@ -20,7 +20,6 @@
         android:layout_marginBottom="5dp"
         android:layout_marginLeft="@dimen/input_edit_text_margin"
         android:layout_marginRight="@dimen/input_edit_text_margin"
-        android:background="@drawable/edit_text_bottom_border"
         android:gravity="left"
         android:inputType="number"
         android:paddingLeft="@dimen/question_padding_all"


### PR DESCRIPTION
### :pushpin: References
* **Issue:** connect #2400 
* **Related pull-requests:** 

### :tophat: What is the goal?

The idea is to lock fields for a manual change.
Either to keep default values or values that have been passed from an "intent in".

This could be configured via a key in the specific data point:
"disabled": "true" (optional and by default value is: "false")

###   :gear: branches 
**app**:
       Origin: maintenance-question_disabled_feature: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

- I have added a new field in question table named disabled
- I have refactored all conversions from API to DB to set this new field
- I have modified DynamicTabAdapter to disable any question with the disabled field equal to true

### :boom: How can it be tested?

**Use Case 1**:  Modify any question in server adding new disable property, realize login and create new survey, the question with disable property to true should be disabled

**Use Case 2**:  From Connect2ConnectExampleApp send an intent where the disabled field has value, connect app should open the survey and the disabled field should have the value and be disabled.

### :floppy_disk: Requires DB migration?

- [ ] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [x] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots