### PR TITLE
Maintenance add question label to screen

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/views/DatePickerFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/DatePickerFragment.java
@@ -1,32 +1,41 @@
 package org.eyeseetea.malariacare.views;
 
+import android.app.AlertDialog;
 import android.app.DatePickerDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
 import android.content.Context;
 import android.content.ContextWrapper;
+import android.content.DialogInterface;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.util.Log;
+import android.view.View;
 import android.widget.DatePicker;
+import android.widget.TextView;
 
+import org.eyeseetea.malariacare.R;
 import org.joda.time.DateTime;
 
 import java.util.Calendar;
 import java.util.IllegalFormatConversionException;
 
 
-public class DatePickerFragment extends DialogFragment implements
-        DatePickerDialog.OnDateSetListener {
+public class DatePickerFragment extends DialogFragment {
 
     private int year;
     private int month;
     private int day;
     private DateTime dateTime;
     private DatePickerDialog.OnDateSetListener onDateSetListener;
-    private DatePickerDialog dialog;
+    private AlertDialog dialog;
+
+    private String title;
+
+    private TextView titleTextView;
+    private DatePicker datePicker;
 
     public void setOnDateSetListener(DatePickerDialog.OnDateSetListener onDateSetListener) {
         this.onDateSetListener = onDateSetListener;
@@ -34,6 +43,14 @@ public class DatePickerFragment extends DialogFragment implements
 
     public void setDateTime(DateTime dateTime) {
         this.dateTime = dateTime;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+
+        if (titleTextView != null) {
+            titleTextView.setText(title);
+        }
     }
 
     @Override
@@ -75,7 +92,7 @@ public class DatePickerFragment extends DialogFragment implements
         }
 
         if (dateTime == null) {
-            // Use the current date as the default date in the picker
+            // Use the current date as the default date in the datePicker
             final Calendar c = Calendar.getInstance();
             year = c.get(Calendar.YEAR);
             month = c.get(Calendar.MONTH);
@@ -86,18 +103,33 @@ public class DatePickerFragment extends DialogFragment implements
             day = dateTime.getDayOfMonth();
         }
 
-        // Create a new instance of DatePickerDialog and return it
-        dialog = new DatePickerDialog(context, this, year, month, day);
+        View view = getActivity().getLayoutInflater().inflate(R.layout.view_date_picker_with_title,
+                null);
+
+        titleTextView = view.findViewById(R.id.date_title_text_view);
+        datePicker = view.findViewById(R.id.date_picker);
+
+        titleTextView.setText(title);
+        datePicker.setCalendarViewShown(false);
+        datePicker.updateDate(year, month, day);
+
+
+        dialog = new AlertDialog.Builder(context)
+                .setView(view)
+                .setNegativeButton(context.getText(android.R.string.cancel), null)
+                .setPositiveButton(context.getText(android.R.string.ok),
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                if (onDateSetListener != null) {
+                                    onDateSetListener.onDateSet(datePicker, datePicker.getYear(),
+                                            datePicker.getMonth() + 1, datePicker.getDayOfMonth());
+                                }
+                            }
+                        })
+                .create();
 
         return dialog;
-    }
-
-    @Override
-    public void onDateSet(DatePicker view, int year, int month, int day) {
-        if (onDateSetListener != null) {
-            onDateSetListener.onDateSet(view, year, month + 1, day);
-        }
-
     }
 
     private static boolean isBrokenSamsungDevice() {

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/DatePickerQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/DatePickerQuestionView.java
@@ -28,6 +28,8 @@ public class DatePickerQuestionView extends CommonQuestionView implements IQuest
     private String TAG = "DatePickerQuestionView";
     private boolean enabled;
 
+    private DatePickerFragment datePickerFragment;
+
 
     public DatePickerQuestionView(Context context) {
         super(context);
@@ -43,6 +45,7 @@ public class DatePickerQuestionView extends CommonQuestionView implements IQuest
     @Override
     public void setHeader(String headerValue) {
         header.setText(headerValue);
+        datePickerFragment.setTitle(headerValue);
     }
 
     @Override
@@ -115,7 +118,8 @@ public class DatePickerQuestionView extends CommonQuestionView implements IQuest
         inflate(context, R.layout.multi_question_tab_year_selector, this);
         header = (TextView) findViewById(R.id.row_header_text);
         dateText = (TextView) findViewById(R.id.answer);
-        final DatePickerFragment datePickerFragment = new DatePickerFragment();
+        datePickerFragment = new DatePickerFragment();
+        datePickerFragment.setTitle(header.getText().toString());
         datePickerFragment.setOnDateSetListener(new DatePickerDialog.OnDateSetListener() {
             @Override
             public void onDateSet(DatePicker view, int year, int monthOfYear, int dayOfMonth) {

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/DropdownMultiQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/DropdownMultiQuestionView.java
@@ -66,6 +66,7 @@ public class DropdownMultiQuestionView extends AOptionQuestionView implements IQ
     @Override
     public void setHeader(String headerValue) {
         header.setText(headerValue);
+        spinnerOptions.setPrompt(headerValue);
     }
 
     @Override

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/DropdownWithFilterMultiQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/DropdownWithFilterMultiQuestionView.java
@@ -12,6 +12,7 @@ import android.widget.AdapterView;
 import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.Spinner;
+import android.widget.TextView;
 
 import org.eyeseetea.malariacare.BuildConfig;
 import org.eyeseetea.malariacare.R;
@@ -204,8 +205,11 @@ public class DropdownWithFilterMultiQuestionView extends AOptionQuestionView imp
         Window window = alertDialog.getWindow();
         window.setLayout(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
         window.setGravity(Gravity.TOP);
-        listView = (ListView) dialog.findViewById(R.id.listView);
-        EditText editText = (EditText) dialog.findViewById(R.id.filter);
+        listView = dialog.findViewById(R.id.listView);
+        TextView headerDialog = dialog.findViewById(R.id.questionHeader);
+        headerDialog.setText(header.getText().toString());
+
+        EditText editText = dialog.findViewById(R.id.filter);
         editText.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/YearSelectorQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/YearSelectorQuestionView.java
@@ -88,6 +88,7 @@ public class YearSelectorQuestionView extends CommonQuestionView implements IQue
             public void onClick(View view) {
                 if (enabled) {
                     YearPicker yearPicker = new YearPicker();
+                    yearPicker.setTitle(header.getText().toString());
                     yearPicker.setInterval(context.getResources().getInteger(R.integer.year_interval));
                     yearPicker.setOnYearSelectedListener(new YearPicker.OnYearSelectedListener() {
                         @Override

--- a/app/src/main/res/layout/dialog_spinner_with_filter.xml
+++ b/app/src/main/res/layout/dialog_spinner_with_filter.xml
@@ -7,8 +7,8 @@
 
     <org.eyeseetea.sdk.presentation.views.CustomTextView
         android:id="@+id/questionHeader"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_gravity="left"
         android:layout_margin="10dp"
         android:gravity="left"
@@ -16,8 +16,8 @@
         android:singleLine="true"
         android:textColor="@color/intColor"
         android:text="edededede"
-        android:textSize="?attr/font_medium"
-        app:font_name="@string/normal_font"
+        android:textSize="?attr/font_large"
+        app:font_name="@string/bold_font"
         android:lines="1" />
 
     <org.eyeseetea.sdk.presentation.views.CustomEditText

--- a/app/src/main/res/layout/dialog_spinner_with_filter.xml
+++ b/app/src/main/res/layout/dialog_spinner_with_filter.xml
@@ -15,7 +15,6 @@
         android:cursorVisible="true"
         android:singleLine="true"
         android:textColor="@color/intColor"
-        android:text="edededede"
         android:textSize="?attr/font_large"
         app:font_name="@string/bold_font"
         android:lines="1" />

--- a/app/src/main/res/layout/dialog_spinner_with_filter.xml
+++ b/app/src/main/res/layout/dialog_spinner_with_filter.xml
@@ -5,6 +5,21 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
+    <org.eyeseetea.sdk.presentation.views.CustomTextView
+        android:id="@+id/questionHeader"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="left"
+        android:layout_margin="10dp"
+        android:gravity="left"
+        android:cursorVisible="true"
+        android:singleLine="true"
+        android:textColor="@color/intColor"
+        android:text="edededede"
+        android:textSize="?attr/font_medium"
+        app:font_name="@string/normal_font"
+        android:lines="1" />
+
     <org.eyeseetea.sdk.presentation.views.CustomEditText
         android:id="@+id/filter"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/view_date_picker_with_title.xml
+++ b/app/src/main/res/layout/view_date_picker_with_title.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical">
+
+    <org.eyeseetea.sdk.presentation.views.CustomTextView
+        android:id="@+id/date_title_text_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="left"
+        android:layout_margin="10dp"
+        android:gravity="left"
+        android:cursorVisible="true"
+        android:singleLine="true"
+        android:textColor="@color/black"
+        android:textSize="?attr/font_large"
+        app:font_name="@string/bold_font"
+        android:lines="1" />
+
+
+    <DatePicker
+        android:id="@+id/date_picker"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"></DatePicker>
+
+</LinearLayout>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2401 
* **Related pull-requests:**  https://github.com/EyeSeeTea/sdk/pull/22

### :tophat: What is the goal?

Add question label to screen for control types:

AUTOCOMPLETE
DROPDOWN_LIST
DATE
YEAR
... (any full screen controls)

###   :gear: branches 
**app**:
       Origin: maintenance-add_question_label_to_screen Target: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: maintenance-add_title_to_year_picker Target: Development
       
### :memo: How is it being implemented?

- I have added title with question to dialog in DropdownWithFilterMultiQuestionView editing dialog layout
- I have added title with question to dialog in DropdownMultiQuestionView setting prompt property
- I have added title with question to dialog in YearSelectorQuestionView  editing dialog layout
- I have added title with question to date dialog in DatePickerQuestionView:
I had problems questionView with different Android versions to set title, then I have refactored the code of DatePickerFragment to show an AlerDialog with a custom view. this one has a textview for title and a DatePicker

### :boom: How can it be tested?

**Use Case 1**:  Create a new survey and fields of type AUTOCOMPLETE, DROPDOWN_LIST, DATE, YEAR dialogs should show title in old android versions and new Android versions.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots
![spinnerwithfilter](https://user-images.githubusercontent.com/5593590/52939242-f19eb600-3363-11e9-8f20-9590669ab3b1.png)
![datedialog](https://user-images.githubusercontent.com/5593590/52939243-f19eb600-3363-11e9-8f48-a2e85629766e.png)
![yeardialog](https://user-images.githubusercontent.com/5593590/52939244-f19eb600-3363-11e9-8c76-6fa413dc4d43.png)
![simplespinner](https://user-images.githubusercontent.com/5593590/52939245-f2374c80-3363-11e9-8a9c-3ec295a81260.png)
