### PR TITLE
Maintenance improve surveys loading

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -381,10 +381,10 @@ dependencies {
     compile "com.squareup:javapoet:${libs.javapoetVersion}"
 
     //DBFlow
-    apt "com.github.Raizlabs.DBFlow:dbflow-processor:${libs.dbFlowVersion}"
-    compile "com.github.Raizlabs.DBFlow:dbflow:${libs.dbFlowVersion}"
-    compile "com.github.Raizlabs.DBFlow:dbflow-core:${libs.dbFlowVersion}"
-    compile "com.github.Raizlabs.DBFlow:dbflow-sqlcipher:${libs.dbFlowVersion}"
+    apt "com.github.agrosner.dbflow:dbflow-processor:${libs.dbFlowVersion}"
+    compile "com.github.agrosner.dbflow:dbflow:${libs.dbFlowVersion}"
+    compile "com.github.agrosner.dbflow:dbflow-core:${libs.dbFlowVersion}"
+    compile "com.github.agrosner.dbflow:dbflow-sqlcipher:${libs.dbFlowVersion}"
     compile(project(path: ':bugshaker')) {
         exclude group: "com.google.android.gms"
     }

--- a/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/data/LoginUseCaseShould.java
+++ b/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/data/LoginUseCaseShould.java
@@ -1,5 +1,8 @@
 package org.eyeseetea.malariacare.data;
 
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
 import android.support.test.InstrumentationRegistry;
 
 import org.eyeseetea.malariacare.AssetsFileReader;
@@ -29,9 +32,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
-
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LoginUseCaseShould {
@@ -84,11 +84,6 @@ public class LoginUseCaseShould {
             }
 
             @Override
-            public void onServerPinChanged() {
-                fail("onLoginSuccess");
-            }
-
-            @Override
             public void onNetworkError() {
                 fail("onNetworkError");
             }
@@ -135,11 +130,6 @@ public class LoginUseCaseShould {
 
             @Override
             public void onInvalidCredentials() {
-                fail("onLoginSuccess");
-            }
-
-            @Override
-            public void onServerPinChanged() {
                 fail("onLoginSuccess");
             }
 

--- a/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/data/sync/exporter/PushUseCaseShould.java
+++ b/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/data/sync/exporter/PushUseCaseShould.java
@@ -6,9 +6,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
-import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-
 import org.eyeseetea.malariacare.AssetsFileReader;
 import org.eyeseetea.malariacare.BuildConfig;
 import org.eyeseetea.malariacare.data.database.datasources.CountryVersionLocalDataSource;
@@ -21,7 +18,6 @@ import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.data.database.model.UserDB;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.data.repositories.OrganisationUnitRepository;
-import org.eyeseetea.malariacare.data.repositories.ProgramRepository;
 import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
 import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IAppInfoRepository;
@@ -42,7 +38,6 @@ import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
 import org.eyeseetea.malariacare.rules.MockWebServerRule;
 import org.eyeseetea.malariacare.utils.Constants;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -151,6 +146,11 @@ public class PushUseCaseShould {
             @Override
             public void onApiCallError(ApiCallException e) {
                 fail("onApiCallError");
+            }
+
+            @Override
+            public void onInvalidCredentials() {
+                fail("onInvalidCredentials");
             }
         });
     }

--- a/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/data/sync/exporter/WSPushControllerShould.java
+++ b/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/data/sync/exporter/WSPushControllerShould.java
@@ -198,6 +198,8 @@ public class WSPushControllerShould {
     }
 
     private void givenSomeQuarantineTestSurveys() {
+        UserDB userDB = new UserDB("test","test");
+        userDB.save();
         ProgramDB programDB = new ProgramDB("test", "uid");
         programDB.save();
         OrgUnitDB orgUnitDB = new OrgUnitDB("test");

--- a/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/services/PushServiceShould.java
+++ b/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/services/PushServiceShould.java
@@ -11,30 +11,21 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.SharedPreferences;
 import android.os.Build;
-import android.preference.PreferenceManager;
 import android.support.test.InstrumentationRegistry;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
 import org.eyeseetea.malariacare.AssetsFileReader;
 import org.eyeseetea.malariacare.BuildConfig;
-import org.eyeseetea.malariacare.R;
-import org.eyeseetea.malariacare.data.database.CredentialsLocalDataSource;
 import org.eyeseetea.malariacare.data.database.datasources.CountryVersionLocalDataSource;
-import org.eyeseetea.malariacare.data.database.datasources.SettingsDataSource;
 import org.eyeseetea.malariacare.data.database.datasources.SurveyLocalDataSource;
-import org.eyeseetea.malariacare.data.database.datasources.UserAccountDataSource;
 import org.eyeseetea.malariacare.data.database.model.OrgUnitDB;
 import org.eyeseetea.malariacare.data.database.model.ProgramDB;
 import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.data.database.model.UserDB;
-import org.eyeseetea.malariacare.data.database.utils.PreferencesEReferral;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.data.repositories.OrganisationUnitRepository;
-import org.eyeseetea.malariacare.data.repositories.ProgramRepository;
-import org.eyeseetea.malariacare.data.server.CustomMockServer;
 import org.eyeseetea.malariacare.data.sync.exporter.ConvertToWSVisitor;
 import org.eyeseetea.malariacare.data.sync.exporter.WSPushController;
 import org.eyeseetea.malariacare.data.sync.exporter.eReferralsAPIClient;
@@ -52,15 +43,12 @@ import org.eyeseetea.malariacare.domain.entity.Credentials;
 import org.eyeseetea.malariacare.domain.entity.Device;
 import org.eyeseetea.malariacare.domain.entity.Program;
 import org.eyeseetea.malariacare.domain.entity.Settings;
-import org.eyeseetea.malariacare.domain.entity.UserAccount;
 import org.eyeseetea.malariacare.domain.usecase.push.PushUseCase;
 import org.eyeseetea.malariacare.domain.usecase.push.SurveysThresholds;
-import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
 import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
 import org.eyeseetea.malariacare.rules.MockWebServerRule;
 import org.eyeseetea.malariacare.services.strategies.PushServiceStrategy;
 import org.eyeseetea.malariacare.utils.Constants;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -140,7 +128,7 @@ public class PushServiceShould {
             showLoginIfConfigFileObsolete(intent);
         }
         private void showLoginIfConfigFileObsolete(Intent intent) {
-            if (intent.getBooleanExtra(PushServiceStrategy.SHOW_LOGIN, false)) {
+            if (intent.getBooleanExtra(PushServiceStrategy.PULL_REQUIRED, false)) {
                 synchronized (syncObject) {
                     pullRequiredIntentReceived = true;
                     syncObject.notify();
@@ -159,7 +147,8 @@ public class PushServiceShould {
         eReferralsAPIClient eReferralsAPIClient = new eReferralsAPIClient(mockWebServerRule.getMockServer().getBaseEndpoint());
         when(mProgramRepository.getUserProgram()).thenReturn(new Program("code","testProgramId"));
         Settings settings = new Settings("en", "en", null, false, false, false,
-                "test", "test", mockWebServerRule.getMockServer().getBaseEndpoint(), null, null, null, null, "1.0");
+                "test", "test", mockWebServerRule.getMockServer().getBaseEndpoint(), null, null,
+                null, null, false, false, "1.0");
         when(mSettingsRepository.getSettings()).thenReturn(settings);
         ConvertToWSVisitor mConvertToWSVisitor = new ConvertToWSVisitor(deviceDataSource, mCredentialsRepository, mSettingsRepository, appInfoDataSource,
                 mProgramRepository, new CountryVersionLocalDataSource());

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/database/datasources/strategies/SurveyLocalDataSourceStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/database/datasources/strategies/SurveyLocalDataSourceStrategy.java
@@ -2,27 +2,19 @@ package org.eyeseetea.malariacare.data.database.datasources.strategies;
 
 import org.eyeseetea.malariacare.data.database.model.ProgramDB;
 import org.eyeseetea.malariacare.data.database.model.UserDB;
-import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
-import org.eyeseetea.malariacare.domain.entity.Program;
-import org.eyeseetea.malariacare.domain.entity.Survey;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesEReferral;
-import org.eyeseetea.malariacare.domain.entity.UserAccount;
+import org.eyeseetea.malariacare.domain.entity.Survey;
 
 public class SurveyLocalDataSourceStrategy extends ASurveyLocalDataSourceStrategy {
     @Override
     public Survey createNewSurvey() {
         ProgramDB programDB = ProgramDB.findById(PreferencesEReferral.getUserProgramId());
         UserDB userDB = UserDB.getLoggedUser();
-        if (programDB == null || userDB == null) {
+
+        if (programDB == null || userDB == null || programDB == null) {
             return null;
         }
-        UserAccount userAccount = new UserAccount(userDB.getName(),
-                userDB.getUid(),
-                PreferencesState.getCredentialsFromPreferences().isDemoCredentials());
-        if (programDB == null) {
-            return null;
-        }
-        Program program = new Program(programDB.getUid(), programDB.getUid());
-        return Survey.createNewSurvey(program, userAccount);
+
+        return Survey.createNewSurvey(programDB.getUid(), userDB.getUid());
     }
 }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/UidsAndCodes.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/UidsAndCodes.java
@@ -1,0 +1,8 @@
+package org.eyeseetea.malariacare.domain;
+
+public class UidsAndCodes {
+    public static final String PHONE_QUESTION_UID = "phoneNumber";
+    public static final String NO_VOUCHER_QUESTION_UID = "generateVoucher";
+
+    public static final String NO_VOUCHER_OPTION_CODE = "NO";
+}

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/fragments/SurveysFragment.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/fragments/SurveysFragment.java
@@ -119,6 +119,13 @@ public class SurveysFragment extends Fragment implements IDashboardFragment, Sur
     }
 
     @Override
+    public void reloadData() {
+        if (presenter != null) {
+            presenter.refresh();
+        }
+    }
+
+    @Override
     public void onDestroyView() {
         super.onDestroyView();
     }
@@ -214,11 +221,6 @@ public class SurveysFragment extends Fragment implements IDashboardFragment, Sur
 
     @Override
     public void unregisterFragmentReceiver() {
-
-    }
-
-    @Override
-    public void reloadData() {
 
     }
 }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/fragments/SurveysFragment.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/fragments/SurveysFragment.java
@@ -67,6 +67,9 @@ public class SurveysFragment extends Fragment implements IDashboardFragment, Sur
 
         rootView = inflater.inflate(R.layout.survey_list_fragment, container, false);
 
+        initRecyclerView();
+        initPresenter();
+
         return rootView;
     }
 
@@ -75,8 +78,6 @@ public class SurveysFragment extends Fragment implements IDashboardFragment, Sur
         Log.d(TAG, "onActivityCreated");
         super.onActivityCreated(savedInstanceState);
 
-        initRecyclerView();
-        initPresenter();
         registerForContextMenu(mRecyclerView);
     }
 
@@ -203,6 +204,7 @@ public class SurveysFragment extends Fragment implements IDashboardFragment, Sur
 
     @Override
     public void showSurveys(List<SurveyViewModel> surveyViewModels) {
+        mSurveyDBs = surveyViewModels;
         adapter.setItems(surveyViewModels);
     }
 

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/layout/SwipeRecyclerViewSurveysCallback.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/layout/SwipeRecyclerViewSurveysCallback.java
@@ -11,8 +11,8 @@ import android.support.v7.widget.helper.ItemTouchHelper;
 import android.view.View;
 
 import org.eyeseetea.malariacare.R;
-import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.layout.adapters.survey.SurveysAdapter;
+import org.eyeseetea.malariacare.presentation.models.SurveyViewModel;
 
 public class SwipeRecyclerViewSurveysCallback extends ItemTouchHelper.SimpleCallback {
 
@@ -22,7 +22,7 @@ public class SwipeRecyclerViewSurveysCallback extends ItemTouchHelper.SimpleCall
     private final ColorDrawable background;
 
     public interface OnSurveySwipeListener {
-        void onSurveySwipe(SurveyDB surveyDB);
+        void onSurveySwipe(SurveyViewModel surveyViewModel);
     }
 
     private OnSurveySwipeListener onSurveySwipeListener;
@@ -49,10 +49,10 @@ public class SwipeRecyclerViewSurveysCallback extends ItemTouchHelper.SimpleCall
 
     @Override
     public void onSwiped(RecyclerView.ViewHolder viewHolder, int direction) {
-        SurveyDB surveyDB = surveysAdapter.getSurvey(viewHolder.getAdapterPosition());
+        SurveyViewModel surveyViewModel = surveysAdapter.getSurvey(viewHolder.getAdapterPosition());
 
         if (onSurveySwipeListener != null) {
-            onSurveySwipeListener.onSurveySwipe(surveyDB);
+            onSurveySwipeListener.onSurveySwipe(surveyViewModel);
         }
     }
 

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/presentation/models/SurveyViewModel.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/presentation/models/SurveyViewModel.java
@@ -1,0 +1,67 @@
+package org.eyeseetea.malariacare.presentation.models;
+
+import java.util.Date;
+import java.util.List;
+
+public class SurveyViewModel {
+
+    private final Date eventDate;
+    private final String uid;
+    private final String voucherUid;
+    private final boolean isCompleted;
+    private final boolean hasPhone;
+    private final boolean noIssueVoucher;
+    private final List<String> importantValues;
+    private final List<String> visibleValues;
+    private final int status;
+
+    public SurveyViewModel(Date eventDate, String uid, String voucherUid,
+            boolean isCompleted, boolean hasPhone, boolean noIssueVoucher,
+            List<String> importantValues, List<String> visibleValues, int status) {
+        this.eventDate = eventDate;
+        this.uid = uid;
+        this.voucherUid = voucherUid;
+        this.isCompleted = isCompleted;
+        this.hasPhone = hasPhone;
+        this.noIssueVoucher = noIssueVoucher;
+        this.importantValues = importantValues;
+        this.visibleValues = visibleValues;
+        this.status = status;
+    }
+
+    public Date getEventDate() {
+        return eventDate;
+    }
+
+    public String getUid() {
+        return uid;
+    }
+
+    public String getVoucherUid() {
+        return voucherUid;
+    }
+
+    public boolean isCompleted() {
+        return isCompleted;
+    }
+
+    public List<String> getImportantValues() {
+        return importantValues;
+    }
+
+    public List<String> getVisibleValues() {
+        return visibleValues;
+    }
+
+    public boolean hasPhone() {
+        return hasPhone;
+    }
+
+    public boolean noIssueVoucher() {
+        return noIssueVoucher;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+}

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/presentation/presenters/SurveysPresenter.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/presentation/presenters/SurveysPresenter.java
@@ -51,6 +51,16 @@ public class SurveysPresenter {
         view = null;
     }
 
+    public void selectSurvey(String surveyUid) {
+        if (view != null) {
+            view.navigateToSurvey(surveyUid);
+        }
+    }
+
+    public void refresh() {
+        loadSurveys();
+    }
+
     public void deleteSurvey(String surveyUid) {
         deleteSurveyUseCase.execute(new DeleteSurveyByUidUseCase.Callback() {
             @Override
@@ -170,12 +180,6 @@ public class SurveysPresenter {
         }
 
         return textValue;
-    }
-
-    public void selectSurvey(String surveyUid) {
-        if (view != null) {
-            view.navigateToSurvey(surveyUid);
-        }
     }
 
     public interface View {

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/presentation/presenters/SurveysPresenter.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/presentation/presenters/SurveysPresenter.java
@@ -1,0 +1,186 @@
+package org.eyeseetea.malariacare.presentation.presenters;
+
+import org.eyeseetea.malariacare.domain.entity.Option;
+import org.eyeseetea.malariacare.domain.entity.Program;
+import org.eyeseetea.malariacare.domain.entity.Question;
+import org.eyeseetea.malariacare.domain.entity.Survey;
+import org.eyeseetea.malariacare.domain.entity.Value;
+import org.eyeseetea.malariacare.domain.usecase.DeleteSurveyByUidUseCase;
+import org.eyeseetea.malariacare.domain.usecase.GetQuestionsByProgramUseCase;
+import org.eyeseetea.malariacare.domain.usecase.GetSurveysByProgram;
+import org.eyeseetea.malariacare.domain.usecase.GetUserProgramUseCase;
+import org.eyeseetea.malariacare.presentation.models.SurveyViewModel;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SurveysPresenter {
+
+    private View view;
+
+    private final GetUserProgramUseCase getUserProgramUseCase;
+    private final GetSurveysByProgram getSurveysByProgram;
+    private final GetQuestionsByProgramUseCase getQuestionsByProgramUseCase;
+    private final DeleteSurveyByUidUseCase deleteSurveyUseCase;
+
+    private List<Survey> surveys;
+    private String programUid;
+    private Map<String, Question> questions;
+
+    public SurveysPresenter(
+            GetUserProgramUseCase getUserProgramUseCase,
+            GetSurveysByProgram getSurveysByProgram,
+            GetQuestionsByProgramUseCase getQuestionsByProgramUseCase,
+            DeleteSurveyByUidUseCase deleteSurveyUseCase) {
+        this.getUserProgramUseCase = getUserProgramUseCase;
+        this.getSurveysByProgram = getSurveysByProgram;
+        this.getQuestionsByProgramUseCase = getQuestionsByProgramUseCase;
+        this.deleteSurveyUseCase = deleteSurveyUseCase;
+    }
+
+    public void attachView(View view) {
+        this.view = view;
+
+        loadData();
+    }
+
+    public void detachView() {
+        view = null;
+    }
+
+    public void deleteSurvey(String surveyUid) {
+        deleteSurveyUseCase.execute(new DeleteSurveyByUidUseCase.Callback() {
+            @Override
+            public void onSurveyDeleted() {
+                loadSurveys();
+            }
+        }, surveyUid);
+    }
+
+    private void loadData() {
+        getUserProgramUseCase.execute(new GetUserProgramUseCase.Callback() {
+            @Override
+            public void onSuccess(Program program) {
+                SurveysPresenter.this.programUid = program.getId();
+                getQuestions();
+            }
+
+            @Override
+            public void onError() {
+                System.out.println("An error has occurred loading user program");
+            }
+        });
+    }
+
+    private void getQuestions() {
+        getQuestionsByProgramUseCase.execute(new GetQuestionsByProgramUseCase.Callback() {
+            @Override
+            public void onGetQuestions(List<Question> questions) {
+
+                SurveysPresenter.this.questions = new HashMap<>();
+
+                for (Question question : questions) {
+                    SurveysPresenter.this.questions.put(question.getUid(), question);
+                }
+
+                loadSurveys();
+            }
+        }, programUid);
+    }
+
+    private void loadSurveys() {
+        getSurveysByProgram.execute(new GetSurveysByProgram.Callback() {
+            @Override
+            public void onGetSurveys(List<Survey> surveys) {
+                SurveysPresenter.this.surveys = surveys;
+
+                showSurveys();
+
+            }
+        }, programUid);
+    }
+
+    private void showSurveys() {
+        List<SurveyViewModel> surveyViewModels = mapToViewModelList(this.surveys);
+
+        if (view != null) {
+            view.showSurveys(surveyViewModels);
+        }
+    }
+
+    private List<SurveyViewModel> mapToViewModelList(List<Survey> surveys) {
+        List<SurveyViewModel> surveyViewModels = new ArrayList<>();
+
+        for (Survey survey : surveys) {
+            SurveyViewModel surveyViewModel = mapToViewModel(survey);
+
+            surveyViewModels.add(surveyViewModel);
+        }
+
+        return surveyViewModels;
+    }
+
+    private SurveyViewModel mapToViewModel(Survey survey) {
+        Date eventDate = survey.getSurveyDate();
+        String uid = survey.getUId();
+        String voucherUid = survey.getVoucherUid();
+        boolean isCompleted = survey.isCompleted();
+        boolean hasPhone = survey.hasPhone();
+        boolean noIssueVoucher = survey.noIssueVoucher();
+        int status = survey.getStatus();
+
+        List<String> importantValues = new ArrayList<>();
+        List<String> visibleValues = new ArrayList<>();
+
+        for (Value value : survey.getValues()) {
+            if (value.getVisibility() == Question.Visibility.IMPORTANT) {
+                importantValues.add(getValue(value));
+            } else if (value.getVisibility() == Question.Visibility.VISIBLE) {
+                visibleValues.add(getValue(value));
+            }
+        }
+
+        SurveyViewModel surveyViewModel =
+                new SurveyViewModel(eventDate, uid, voucherUid, isCompleted,
+                        hasPhone, noIssueVoucher, importantValues, visibleValues, status);
+
+        return surveyViewModel;
+    }
+
+    private String getValue(Value value) {
+        Option optionSelected = null;
+
+        if (value.getOptionCode() != null) {
+            for (Option option : questions.get(value.getQuestionUId()).getOptions()) {
+                if (option.getCode().equals(value.getOptionCode())) {
+                    optionSelected = option;
+                }
+            }
+        }
+
+        String textValue;
+
+        if (optionSelected != null) {
+            textValue = optionSelected.getName();
+        } else {
+            textValue = value.getValue();
+        }
+
+        return textValue;
+    }
+
+    public void selectSurvey(String surveyUid) {
+        if (view != null) {
+            view.navigateToSurvey(surveyUid);
+        }
+    }
+
+    public interface View {
+        void showSurveys(List<SurveyViewModel> surveyViewModels);
+
+        void navigateToSurvey(String surveyUid);
+    }
+}

--- a/app/src/ereferrals/res/values/donottranslate.xml
+++ b/app/src/ereferrals/res/values/donottranslate.xml
@@ -41,14 +41,15 @@
     <string name="ws_version">1.0</string>
     <string name="ws_source">Android v1.1</string>
     <string name="can_add_new_surveys" translatable="false">canAddNewSurveys</string>
-    <string name="phone_ownership_qc" translatable="false">phoneOwnership</string>
     <string name="no_phone_oc" translatable="false">NO</string>
     <string name="no_phone_on" translatable="false">common_option_ownershipOfPhone_noMobile</string>
     <string name="last_username_inserted_preference">last_username_inserted_preference</string>
-    <string name="issue_voucher_qc" translatable="false">generateVoucher</string>
     <string name="no_voucher_on" translatable="false">common_btn_no</string>
     <string name="demo_program_uid" translatable="false">demoProgram</string>
     <string name="default_language" translatable="false">en</string>
+
+    <string name="phone_ownership_qc" translatable="false">phoneOwnership</string>
+    <string name="issue_voucher_qc" translatable="false">generateVoucher</string>
 
     <string name="lastcommit_unavailable" translatable="false"><![CDATA[
     <p>This option requires some changes in the git repository.</p>

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/SurveyLocalDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/SurveyLocalDataSource.java
@@ -196,6 +196,17 @@ public class SurveyLocalDataSource implements ISurveyRepository {
 
         List<Value> values = getValuesFromSurvey(surveyDB);
 
+        String programUid = null;
+        String orgUnitUid = null;
+
+        if (programDBS.size() > 0){
+            programUid = programDBS.get(surveyDB.getId_program_fk()).getUid();
+        }
+
+        if (orgUnitDBS.size() > 0){
+            orgUnitUid = orgUnitDBS.get(surveyDB.getId_org_unit_fk()).getUid();
+        }
+
         Survey survey = new Survey(
                 surveyDB.getId_survey(),
                 surveyDB.getEventUid(),
@@ -203,8 +214,8 @@ public class SurveyLocalDataSource implements ISurveyRepository {
                 surveyDB.getStatus(),
                 null,
                 surveyDB.getEventDate(),
-                programDBS.get(surveyDB.getId_program_fk()).getUid(),
-                orgUnitDBS.get(surveyDB.getId_org_unit_fk()).getUid(),
+                programUid,
+                orgUnitUid,
                 userDB.getUid(),
                 surveyDB.getType(),
                 values);

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/SurveyLocalDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/SurveyLocalDataSource.java
@@ -30,26 +30,36 @@ public class SurveyLocalDataSource implements ISurveyRepository {
     private final Map<Long, OrgUnitDB> orgUnitDBS = new HashMap<>();
     private final Map<Long, QuestionDB> questionsDBs = new HashMap<>();
     private final Map<Long, OptionDB> optionDBs = new HashMap<>();
-    private final UserDB userDB;
+    private UserDB userDB;
 
-    public SurveyLocalDataSource() {
-        for (ProgramDB programDB : ProgramDB.getAllPrograms()) {
-            programDBS.put(programDB.getId_program(), programDB);
+    private void loadDependencies() {
+        if (programDBS.size() == 0) {
+            for (ProgramDB programDB : ProgramDB.getAllPrograms()) {
+                programDBS.put(programDB.getId_program(), programDB);
+            }
         }
 
-        for (OrgUnitDB orgUnitDB : OrgUnitDB.getAllOrgUnit()) {
-            orgUnitDBS.put(orgUnitDB.getId_org_unit(), orgUnitDB);
+        if (orgUnitDBS.size() == 0) {
+            for (OrgUnitDB orgUnitDB : OrgUnitDB.getAllOrgUnit()) {
+                orgUnitDBS.put(orgUnitDB.getId_org_unit(), orgUnitDB);
+            }
         }
 
-        for (QuestionDB questionDB : QuestionDB.getAllQuestions()) {
-            questionsDBs.put(questionDB.getId_question(), questionDB);
+        if (questionsDBs.size() == 0) {
+            for (QuestionDB questionDB : QuestionDB.getAllQuestions()) {
+                questionsDBs.put(questionDB.getId_question(), questionDB);
+            }
         }
 
-        for (OptionDB optionDB : OptionDB.getAllOptions()) {
-            optionDBs.put(optionDB.getId_option(), optionDB);
+        if (optionDBs.size() == 0) {
+            for (OptionDB optionDB : OptionDB.getAllOptions()) {
+                optionDBs.put(optionDB.getId_option(), optionDB);
+            }
         }
 
-        userDB = UserDB.getLoggedUser();
+        if (userDB == null) {
+            userDB = UserDB.getLoggedUser();
+        }
     }
 
     @Override
@@ -182,6 +192,8 @@ public class SurveyLocalDataSource implements ISurveyRepository {
     }
 
     private Survey mapSurvey(SurveyDB surveyDB) {
+        loadDependencies();
+
         List<Value> values = getValuesFromSurvey(surveyDB);
 
         Survey survey = new Survey(
@@ -192,7 +204,7 @@ public class SurveyLocalDataSource implements ISurveyRepository {
                 null,
                 surveyDB.getEventDate(),
                 programDBS.get(surveyDB.getId_program_fk()).getUid(),
-                programDBS.get(surveyDB.getId_program_fk()).getUid(),
+                orgUnitDBS.get(surveyDB.getId_org_unit_fk()).getUid(),
                 userDB.getUid(),
                 surveyDB.getType(),
                 values);

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/SurveyLocalDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/SurveyLocalDataSource.java
@@ -1,8 +1,7 @@
 package org.eyeseetea.malariacare.data.database.datasources;
 
 import org.eyeseetea.malariacare.data.IDataSourceCallback;
-import org.eyeseetea.malariacare.data.database.datasources.strategies
-        .ASurveyLocalDataSourceStrategy;
+import org.eyeseetea.malariacare.data.database.datasources.strategies.ASurveyLocalDataSourceStrategy;
 import org.eyeseetea.malariacare.data.database.datasources.strategies.SurveyLocalDataSourceStrategy;
 import org.eyeseetea.malariacare.data.database.model.OrgUnitDB;
 import org.eyeseetea.malariacare.data.database.model.ProgramDB;
@@ -126,7 +125,7 @@ public class SurveyLocalDataSource implements ISurveyRepository {
 
 
     public List<Survey> getSurveysByProgram(String uid) {
-        List<SurveyDB> surveysDB = SurveyDB.getSurveysWithProgram(uid);
+        List<SurveyDB> surveysDB = SurveyDB.getAllSurveysByProgram(uid);
         List<Survey> surveys = new ArrayList<>();
 
         for (SurveyDB surveyDB : surveysDB) {

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/model/SurveyDB.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/model/SurveyDB.java
@@ -32,7 +32,6 @@ import static org.eyeseetea.malariacare.data.database.AppDatabase.surveyName;
 import static org.eyeseetea.malariacare.data.database.AppDatabase.valueAlias;
 import static org.eyeseetea.malariacare.data.database.AppDatabase.valueName;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
@@ -356,18 +355,6 @@ public class SurveyDB extends BaseModel implements VisitableToSDK {
                         SurveyDB_Table.id_org_unit_fk.withTable(surveyAlias))).queryList();
     }
 
-    public static List<SurveyDB> getAllSurveysByProgram(String malariaProgramUid) {
-        return new Select().from(SurveyDB.class).as(surveyName).join(ProgramDB.class,
-                Join.JoinType.LEFT_OUTER).as(programName)
-                .on(SurveyDB_Table.id_program_fk.withTable(surveyAlias)
-                        .eq(ProgramDB_Table.id_program.withTable(programAlias)))
-                .where(ProgramDB_Table.uid_program.withTable(programAlias)
-                        .is(malariaProgramUid))
-                .and(SurveyDB_Table.status.withTable(surveyAlias).isNot(Constants.SURVEY_IN_PROGRESS))
-                .orderBy(OrderBy.fromProperty(SurveyDB_Table.event_date.withTable(surveyAlias)))
-                .orderBy(OrderBy.fromProperty(
-                        SurveyDB_Table.id_org_unit_fk.withTable(surveyAlias))).queryList();
-    }
     /**
      * Returns all the malaria surveys with status put to "Sent"
      */
@@ -583,7 +570,8 @@ public class SurveyDB extends BaseModel implements VisitableToSDK {
                 .and(SurveyDB_Table.type.withTable(surveyAlias).is(type)).queryList();
     }
 
-    public static List<SurveyDB> getSurveysWithProgram(String programUID) {
+
+    public static List<SurveyDB> getAllSurveysByProgram(String programUID) {
         return new Select().from(SurveyDB.class).as(surveyName)
                 .join(ProgramDB.class, Join.JoinType.LEFT_OUTER).as(programName)
                 .on(SurveyDB_Table.id_program_fk.withTable(surveyAlias)

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/model/SurveyDB.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/model/SurveyDB.java
@@ -244,6 +244,18 @@ public class SurveyDB extends BaseModel implements VisitableToSDK {
         this.id_program_fk = (programDB != null) ? programDB.getId_program() : null;
     }
 
+    public Long getId_program_fk() {
+        return id_program_fk;
+    }
+
+    public Long getId_org_unit_fk() {
+        return id_org_unit_fk;
+    }
+
+    public Long getId_user_fk() {
+        return id_user_fk;
+    }
+
     public UserDB getUserDB() {
         if (mUserDB == null) {
             if (id_user_fk == null) return null;

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/model/ValueDB.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/model/ValueDB.java
@@ -170,6 +170,14 @@ public class ValueDB extends BaseModel {
         this.mQuestionDB = null;
     }
 
+    public Long getId_question_fk() {
+        return id_question_fk;
+    }
+
+    public Long getId_option_fk() {
+        return id_option_fk;
+    }
+
     public String getValue() {
         return value;
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/boundary/repositories/ISurveyRepository.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/boundary/repositories/ISurveyRepository.java
@@ -28,4 +28,6 @@ public interface ISurveyRepository {
     Survey createNewSurvey();
 
     void removeInProgress();
+
+    void deleteSurveyByUid(String surveyUid);
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Survey.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Survey.java
@@ -1,8 +1,9 @@
 package org.eyeseetea.malariacare.domain.entity;
 
-import org.eyeseetea.malariacare.utils.Constants;
-
 import static org.eyeseetea.malariacare.domain.utils.RequiredChecker.required;
+
+import org.eyeseetea.malariacare.domain.UidsAndCodes;
+import org.eyeseetea.malariacare.utils.Constants;
 
 import java.util.Date;
 import java.util.List;
@@ -13,41 +14,39 @@ public class Survey {
     private int status;
     private SurveyAnsweredRatio mSurveyAnsweredRatio;
     private Date mSurveyDate;
-    private Program mProgram;
-    private OrganisationUnit mOrganisationUnit;
-    private UserAccount mUserAccount;
+    private String programUid;
+    private String orgUnitUid;
+    private String userUid;
     private int mType;
-    private List<Question> questions;
+    private List<Value> values;
+    private String voucherUid;
 
-    public Survey(long id, String uid, int status,
+    public Survey(long id, String uid, String voucherUid, int status,
             SurveyAnsweredRatio surveyAnsweredRatio, Date surveyDate,
-            Program program, OrganisationUnit organisationUnit,
-            UserAccount userAccount, int type,
-            List<Question> questions) {
+            String programUid, String orgUnitUid, String userUid, int type,
+            List<Value> values) {
         this.id = id;
         this.uid = uid;
+        this.voucherUid = voucherUid;
         this.status = status;
-        mSurveyAnsweredRatio = surveyAnsweredRatio;
-        mSurveyDate = surveyDate;
-        mProgram = required(program, "Program is required");
-        mOrganisationUnit = organisationUnit;
-        mUserAccount = userAccount;
-        mType = required(type, "Type is required");
-        this.questions = questions;
+        this.mSurveyAnsweredRatio = surveyAnsweredRatio;
+        this.mSurveyDate = surveyDate;
+        this.programUid = required(programUid, "programUid is required");
+        this.orgUnitUid = orgUnitUid;
+        this.userUid = userUid;
+        this.mType = required(type, "Type is required");
+        this.values = values;
     }
 
-    public Survey(Program program,
-            OrganisationUnit organisationUnit,
-            UserAccount userAccount, int type) {
-        mProgram = required(program, "Program is required");
-        mOrganisationUnit = organisationUnit;
-        mUserAccount = userAccount;
-        mType = required(type, "Type is required");
+    public Survey(String programUid, String orgUnitUid, String userUid, int type) {
+        this.programUid = required(programUid, "programUid is required");
+        this.orgUnitUid = orgUnitUid;
+        this.userUid = userUid;
+        this.mType = required(type, "Type is required");
     }
 
-    public static Survey createNewSurvey(Program program,
-                                                UserAccount userAccount) {
-        Survey survey = new Survey(program, null, userAccount, Constants.SURVEY_NO_TYPE);
+    public static Survey createNewSurvey(String programUid, String userUid) {
+        Survey survey = new Survey(programUid, null, userUid, Constants.SURVEY_NO_TYPE);
         survey.setStatus(Constants.SURVEY_IN_PROGRESS);
         return survey;
     }
@@ -75,6 +74,27 @@ public class Survey {
         this.id = id;
     }
 
+
+    public String getUid() {
+        return uid;
+    }
+
+    public String getProgramUid() {
+        return programUid;
+    }
+
+    public String getOrgUnitUid() {
+        return orgUnitUid;
+    }
+
+    public String getUserUid() {
+        return userUid;
+    }
+
+    public List<Value> getValues() {
+        return values;
+    }
+
     public int getStatus() {
         return status;
     }
@@ -87,24 +107,52 @@ public class Survey {
         return mSurveyAnsweredRatio;
     }
 
-    public Program getProgram() {
-        return mProgram;
-    }
-
-    public OrganisationUnit getOrganisationUnit() {
-        return mOrganisationUnit;
-    }
-
-    public UserAccount getUserAccount() {
-        return mUserAccount;
-    }
 
     public int getType() {
         return mType;
     }
 
-    public List<Question> getQuestions() {
-        return questions;
+
+    public Date getSurveyDate() {
+        return mSurveyDate;
+    }
+
+    public String getUId() {
+        return uid;
+    }
+
+    public String getVoucherUid() {
+        return voucherUid;
+    }
+
+    public boolean isCompleted() {
+        return this.status == Constants.SURVEY_COMPLETED;
+    }
+
+    public boolean hasPhone() {
+        boolean hasPhone = false;
+
+        for (Value value : values) {
+            if (value.questionUId.equals(UidsAndCodes.PHONE_QUESTION_UID)) {
+                hasPhone = true;
+            }
+        }
+
+        return hasPhone;
+    }
+
+    public boolean noIssueVoucher() {
+        boolean noIssueVoucher = false;
+
+        for (Value value : values) {
+            if (value.optionCode != null &&
+                    value.questionUId.equals(UidsAndCodes.NO_VOUCHER_QUESTION_UID) &&
+                    value.optionCode.equals(UidsAndCodes.NO_VOUCHER_OPTION_CODE)) {
+                noIssueVoucher = true;
+            }
+        }
+
+        return noIssueVoucher;
     }
 
     @Override
@@ -115,16 +163,12 @@ public class Survey {
                 ", status=" + status +
                 ", mSurveyAnsweredRatio=" + mSurveyAnsweredRatio +
                 ", mSurveyDate=" + mSurveyDate +
-                ", mProgram=" + mProgram +
-                ", mOrganisationUnit=" + mOrganisationUnit +
-                ", mUserAccount=" + mUserAccount +
+                ", programUid=" + programUid +
+                ", orgUnitUid=" + orgUnitUid +
+                ", userUid=" + userUid +
                 ", mType=" + mType +
-                ", questions=" + questions +
+                ", values =" + values +
                 '}';
-    }
-
-    public Date getSurveyDate() {
-        return mSurveyDate;
     }
 
     @Override
@@ -149,18 +193,20 @@ public class Survey {
                 : survey.uid != null) {
             return false;
         }
-        if (mProgram != null ? !mProgram.equals(survey.mProgram) : survey.mProgram != null) {
+        if (orgUnitUid != null ? !orgUnitUid.equals(survey.orgUnitUid)
+                : survey.orgUnitUid != null) {
             return false;
         }
-        if (mOrganisationUnit != null ? !mOrganisationUnit.equals(survey.mOrganisationUnit)
-                : survey.mOrganisationUnit != null) {
+        if (orgUnitUid != null ? !orgUnitUid.equals(survey.orgUnitUid)
+                : survey.orgUnitUid != null) {
             return false;
         }
-        if (mUserAccount != null ? !mUserAccount.equals(survey.mUserAccount)
-                : survey.mUserAccount != null) {
+        if (userUid != null ? !userUid.equals(survey.userUid)
+                : survey.userUid != null) {
             return false;
         }
-        return questions != null ? questions.equals(survey.questions) : survey.questions == null;
+
+        return values != null ? values.equals(survey.values) : survey.values == null;
     }
 
     @Override
@@ -170,94 +216,11 @@ public class Survey {
         result = 31 * result + (mSurveyAnsweredRatio != null ? mSurveyAnsweredRatio.hashCode() : 0);
         result = 31 * result + (mSurveyDate != null ? mSurveyDate.hashCode() : 0);
         result = 31 * result + (uid != null ? uid.hashCode() : 0);
-        result = 31 * result + (mProgram != null ? mProgram.hashCode() : 0);
-        result = 31 * result + (mOrganisationUnit != null ? mOrganisationUnit.hashCode() : 0);
-        result = 31 * result + (mUserAccount != null ? mUserAccount.hashCode() : 0);
+        result = 31 * result + (programUid != null ? programUid.hashCode() : 0);
+        result = 31 * result + (orgUnitUid != null ? orgUnitUid.hashCode() : 0);
+        result = 31 * result + (userUid != null ? userUid.hashCode() : 0);
         result = 31 * result + mType;
-        result = 31 * result + (questions != null ? questions.hashCode() : 0);
+        result = 31 * result + (values != null ? values.hashCode() : 0);
         return result;
-    }
-
-    public String getUId() {
-        return uid;
-    }
-
-    public static final class Builder {
-        private long id;
-        private String uid;
-        private int status;
-        private SurveyAnsweredRatio mSurveyAnsweredRatio;
-        private Date mSurveyDate;
-        private Program mProgram;
-        private OrganisationUnit mOrganisationUnit;
-        private UserAccount mUserAccount;
-        private int mType;
-        private List<Question> questions;
-
-        public Builder() {
-        }
-
-        public Builder id(long id) {
-            this.id = id;
-            return this;
-        }
-        public Builder uid(String uid) {
-            this.uid = uid;
-            return this;
-        }
-
-
-        public Builder status(int status) {
-            this.status = status;
-            return this;
-        }
-
-        public Builder surveyAnsweredRatio(SurveyAnsweredRatio surveyAnsweredRatio) {
-            mSurveyAnsweredRatio = surveyAnsweredRatio;
-            return this;
-        }
-
-        public Builder surveyDate(Date surveyDate) {
-            mSurveyDate = surveyDate;
-            return this;
-        }
-
-        public Builder program(Program program) {
-            mProgram = program;
-            return this;
-        }
-
-        public Builder organisationUnit(OrganisationUnit organisationUnit) {
-            mOrganisationUnit = organisationUnit;
-            return this;
-        }
-
-        public Builder usserAccount(UserAccount userAccount) {
-            mUserAccount = userAccount;
-            return this;
-        }
-
-        public Builder type(int type) {
-            mType = type;
-            return this;
-        }
-
-        public Builder questions(List<Question> questions) {
-            this.questions = questions;
-            return this;
-        }
-
-        public Survey build() {
-            return new Survey(id,
-                    uid,
-                    status,
-                    mSurveyAnsweredRatio,
-                    mSurveyDate,
-                    mProgram,
-                    mOrganisationUnit,
-                    mUserAccount,
-                    mType,
-                    questions);
-        }
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Value.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Value.java
@@ -8,6 +8,7 @@ public class Value {
     String backgroundColor;
     String questionUId;
     String optionCode;
+    private Question.Visibility visibility;
 
     public Value(String value) {
         this.value = value;
@@ -58,5 +59,13 @@ public class Value {
 
     public void setOptionCode(String optionCode) {
         this.optionCode = optionCode;
+    }
+
+    public Question.Visibility getVisibility() {
+        return visibility;
+    }
+
+    public void setVisibility(Question.Visibility visibility) {
+        this.visibility = visibility;
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/CreateSurveyUseCase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/CreateSurveyUseCase.java
@@ -8,7 +8,6 @@ import org.eyeseetea.malariacare.domain.boundary.repositories.ISurveyRepository;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IUserRepository;
 import org.eyeseetea.malariacare.domain.boundary.repositories.ReadPolicy;
 import org.eyeseetea.malariacare.domain.entity.OrganisationUnit;
-import org.eyeseetea.malariacare.domain.entity.Program;
 import org.eyeseetea.malariacare.domain.entity.Survey;
 import org.eyeseetea.malariacare.domain.entity.UserAccount;
 import org.eyeseetea.malariacare.domain.exception.ApiCallException;
@@ -51,12 +50,12 @@ public class CreateSurveyUseCase implements UseCase {
     @Override
     public void run() {
         try {
-            Program program = mProgramRepository.getProgramWithId(mProgramUID);
             UserAccount userAccount = mUserRepository.getLoggedUser();
             OrganisationUnit organisationUnit =
                     mOrganisationUnitRepository.getCurrentOrganisationUnit(
                             ReadPolicy.CACHE);
-            Survey survey = new Survey(program, organisationUnit, userAccount,
+            Survey survey = new Survey(mProgramUID, organisationUnit.getUid(),
+                    userAccount.getUserUid(),
                     mSurveyType);
             long idSurvey = mSurveyRepository.save(survey);
             survey.setId(idSurvey);

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/DeleteSurveyByUidUseCase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/DeleteSurveyByUidUseCase.java
@@ -1,0 +1,53 @@
+package org.eyeseetea.malariacare.domain.usecase;
+
+import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
+import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
+import org.eyeseetea.malariacare.domain.boundary.repositories.ISurveyRepository;
+
+public class DeleteSurveyByUidUseCase implements UseCase {
+
+    private IAsyncExecutor mAsyncExecutor;
+    private IMainExecutor mMainExecutor;
+    private ISurveyRepository mSurveyRepository;
+    private Callback mCallback;
+    private String surveyUid;
+
+    public DeleteSurveyByUidUseCase(
+            IAsyncExecutor asyncExecutor,
+            IMainExecutor mainExecutor,
+            ISurveyRepository surveyRepository) {
+        mAsyncExecutor = asyncExecutor;
+        mMainExecutor = mainExecutor;
+        mSurveyRepository = surveyRepository;
+    }
+
+    public void execute(Callback callback, String surveyUid) {
+        mCallback = callback;
+        this.surveyUid = surveyUid;
+        mAsyncExecutor.run(this);
+    }
+
+    @Override
+    public void run() {
+        try {
+            mSurveyRepository.deleteSurveyByUid(surveyUid);
+            notifyOnSurveyDeleted();
+        } catch (Exception e) {
+            System.out.println("An error has occurred deleting a survey:" + surveyUid);
+        }
+    }
+
+    private void notifyOnSurveyDeleted() {
+        mMainExecutor.run(new Runnable() {
+            @Override
+            public void run() {
+                mCallback.onSurveyDeleted();
+            }
+        });
+    }
+
+    public interface Callback {
+        void onSurveyDeleted();
+    }
+
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/GetUserProgramUseCase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/GetUserProgramUseCase.java
@@ -3,14 +3,15 @@ package org.eyeseetea.malariacare.domain.usecase;
 import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
 import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IProgramRepository;
+import org.eyeseetea.malariacare.domain.entity.Program;
 
-public class GetUserProgramUIDUseCase implements UseCase {
+public class GetUserProgramUseCase implements UseCase {
     private IProgramRepository mProgramRepository;
     private Callback mCallback;
     private IMainExecutor mMainExecutor;
     private IAsyncExecutor mAsyncExecutor;
 
-    public GetUserProgramUIDUseCase(
+    public GetUserProgramUseCase(
             IProgramRepository programRepository,
             IMainExecutor mainExecutor,
             IAsyncExecutor asyncExecutor) {
@@ -26,12 +27,12 @@ public class GetUserProgramUIDUseCase implements UseCase {
 
     @Override
     public void run() {
-        final String uid = mProgramRepository.getUserProgram().getId();
-        if (uid != null && !uid.isEmpty()) {
+        final Program program = mProgramRepository.getUserProgram();
+        if (program != null) {
             mMainExecutor.run(new Runnable() {
                 @Override
                 public void run() {
-                    mCallback.onSuccess(uid);
+                    mCallback.onSuccess(program);
                 }
             });
         } else {
@@ -45,7 +46,7 @@ public class GetUserProgramUIDUseCase implements UseCase {
     }
 
     public interface Callback {
-        void onSuccess(String uid);
+        void onSuccess(Program program);
 
         void onError();
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/factories/MetadataFactory.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/factories/MetadataFactory.java
@@ -1,0 +1,31 @@
+package org.eyeseetea.malariacare.factories;
+
+import org.eyeseetea.malariacare.data.database.datasources.QuestionLocalDataSource;
+import org.eyeseetea.malariacare.data.repositories.ProgramRepository;
+import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
+import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
+import org.eyeseetea.malariacare.domain.boundary.repositories.IProgramRepository;
+import org.eyeseetea.malariacare.domain.boundary.repositories.IQuestionRepository;
+import org.eyeseetea.malariacare.domain.usecase.GetQuestionsByProgramUseCase;
+import org.eyeseetea.malariacare.domain.usecase.GetUserProgramUseCase;
+import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
+import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
+
+public class MetadataFactory {
+    protected IMainExecutor mainExecutor = new UIThreadExecutor();
+    protected IAsyncExecutor asyncExecutor = new AsyncExecutor();
+
+    public GetUserProgramUseCase getUserProgramUseCase() {
+        IProgramRepository programRepository = new ProgramRepository();
+
+        return new GetUserProgramUseCase(
+                programRepository, mainExecutor, asyncExecutor);
+    }
+
+    public GetQuestionsByProgramUseCase getQuestionsByProgramUseCase() {
+        IQuestionRepository questionRepository = new QuestionLocalDataSource();
+
+        return new GetQuestionsByProgramUseCase(
+                mainExecutor, asyncExecutor, questionRepository);
+    }
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/factories/SurveyFactory.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/factories/SurveyFactory.java
@@ -1,0 +1,31 @@
+package org.eyeseetea.malariacare.factories;
+
+import org.eyeseetea.malariacare.data.database.datasources.SurveyLocalDataSource;
+import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
+import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
+import org.eyeseetea.malariacare.domain.boundary.repositories.ISurveyRepository;
+import org.eyeseetea.malariacare.domain.usecase.DeleteSurveyByUidUseCase;
+import org.eyeseetea.malariacare.domain.usecase.GetSurveysByProgram;
+import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
+import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
+
+public class SurveyFactory {
+    protected IMainExecutor mainExecutor = new UIThreadExecutor();
+    protected IAsyncExecutor asyncExecutor = new AsyncExecutor();
+
+    ISurveyRepository surveyRepository = new SurveyLocalDataSource();
+
+    public GetSurveysByProgram getSurveysUseCaseByprogram() {
+        GetSurveysByProgram getSurveysByProgram =
+                new GetSurveysByProgram(asyncExecutor, mainExecutor, surveyRepository);
+
+        return getSurveysByProgram;
+    }
+
+    public DeleteSurveyByUidUseCase deleteSurveyByUidUseCase() {
+        DeleteSurveyByUidUseCase deleteSurveyByUidUseCase =
+                new DeleteSurveyByUidUseCase(asyncExecutor, mainExecutor, surveyRepository);
+
+        return deleteSurveyByUidUseCase;
+    }
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/services/SurveyService.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/services/SurveyService.java
@@ -34,7 +34,8 @@ import org.eyeseetea.malariacare.data.repositories.ProgramRepository;
 import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
 import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IProgramRepository;
-import org.eyeseetea.malariacare.domain.usecase.GetUserProgramUIDUseCase;
+import org.eyeseetea.malariacare.domain.entity.Program;
+import org.eyeseetea.malariacare.domain.usecase.GetUserProgramUseCase;
 import org.eyeseetea.malariacare.layout.score.ScoreRegister;
 import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
 import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
@@ -288,13 +289,13 @@ public class SurveyService extends IntentService {
             IProgramRepository programRepository = new ProgramRepository();
             IMainExecutor mainExecutor = new UIThreadExecutor();
             IAsyncExecutor asyncExecutor = new AsyncExecutor();
-            GetUserProgramUIDUseCase getUserProgramUIDUseCase = new GetUserProgramUIDUseCase(
+            GetUserProgramUseCase getUserProgramUseCase = new GetUserProgramUseCase(
                     programRepository, mainExecutor, asyncExecutor);
-            getUserProgramUIDUseCase.execute(new GetUserProgramUIDUseCase.Callback() {
+            getUserProgramUseCase.execute(new GetUserProgramUseCase.Callback() {
                 @Override
-                public void onSuccess(String uid) {
-                    mProgramUID = uid;
-                    callback.onSuccess(uid);
+                public void onSuccess(Program program) {
+                    mProgramUID = program.getId();
+                    callback.onSuccess(mProgramUID);
                 }
 
                 @Override

--- a/app/src/main/java/org/eyeseetea/malariacare/services/SurveyService.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/services/SurveyService.java
@@ -40,7 +40,6 @@ import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
 import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
 import org.eyeseetea.malariacare.services.strategies.SurveyServiceStrategy;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -312,7 +311,7 @@ public class SurveyService extends IntentService {
 
     private void getSurveysFromProgram(Intent intent) {
         String programUID = intent.getExtras().getString(PROGRAM_UID);
-        List<SurveyDB> surveys = SurveyDB.getSurveysWithProgram(programUID);
+        List<SurveyDB> surveys = SurveyDB.getAllSurveysByProgram(programUID);
 
         Session.putServiceValue(GET_SURVEYS_FROM_PROGRAM, surveys);
 

--- a/app/src/testEreferrals/java/org/eyeseetea/malariacare/domain/usecases/SoftLoginUseCaseShould.java
+++ b/app/src/testEreferrals/java/org/eyeseetea/malariacare/domain/usecases/SoftLoginUseCaseShould.java
@@ -7,6 +7,7 @@ import org.eyeseetea.malariacare.common.FileReader;
 import org.eyeseetea.malariacare.data.IAuthenticationDataSource;
 import org.eyeseetea.malariacare.data.authentication.AuthenticationManager;
 import org.eyeseetea.malariacare.data.remote.AuthenticationWSDataSource;
+import org.eyeseetea.malariacare.data.remote.IForgotPasswordDataSource;
 import org.eyeseetea.malariacare.data.rules.MockWebServerRule;
 import org.eyeseetea.malariacare.data.sync.exporter.eReferralsAPIClient;
 import org.eyeseetea.malariacare.domain.boundary.IAuthenticationManager;
@@ -15,6 +16,7 @@ import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
 import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
 import org.eyeseetea.malariacare.domain.boundary.repositories.ICredentialsRepository;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IInvalidLoginAttemptsRepository;
+import org.eyeseetea.malariacare.domain.boundary.repositories.ISettingsRepository;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IUserRepository;
 import org.eyeseetea.malariacare.domain.entity.Credentials;
 import org.eyeseetea.malariacare.domain.entity.InvalidLoginAttempts;
@@ -35,6 +37,7 @@ import java.util.Date;
 public class SoftLoginUseCaseShould {
     private static final String AUTH_SUCCESS = "authSuccess.json";
     private static final String AUTH_FAIL = "authFail.json";
+    private static final String API_AVAILABLE_OK = "api_available_ok.json";
     private static final long DISABLE_LOGIN_BY_ATTEMPTS = 30000;
 
     @Rule
@@ -57,12 +60,19 @@ public class SoftLoginUseCaseShould {
     @Mock
     IUserRepository userRepository;
 
+    @Mock
+    ISettingsRepository settingsRepository;
+
+    @Mock
+    IForgotPasswordDataSource forgotPasswordDataSource;
+
     @Test
     public void return_on_soft_login_success_if_exists_connection_and_credentials_are_ok()
             throws IOException {
 
         SoftLoginUseCase softLoginUseCase = givenASoftLoginUseCase(true);
 
+        mockWebServerRule.enqueueMockResponseFileName(200, API_AVAILABLE_OK);
         mockWebServerRule.enqueueMockResponseFileName(200, AUTH_SUCCESS);
 
         softLoginUseCase.execute("1234", new SoftLoginUseCase.Callback() {
@@ -85,6 +95,11 @@ public class SoftLoginUseCaseShould {
             public void onMaxInvalidLoginAttemptsError(long enableLoginTime) {
                 fail("onMaxInvalidLoginAttemptsError");
             }
+
+            @Override
+            public void onServerNotAvailable(String message) {
+                fail("onServerNotAvailable");
+            }
         });
     }
 
@@ -94,6 +109,7 @@ public class SoftLoginUseCaseShould {
 
         SoftLoginUseCase softLoginUseCase = givenASoftLoginUseCase(true);
 
+        mockWebServerRule.enqueueMockResponseFileName(200, API_AVAILABLE_OK);
         mockWebServerRule.enqueueMockResponseFileName(200, AUTH_FAIL);
 
         softLoginUseCase.execute("1234", new SoftLoginUseCase.Callback() {
@@ -116,6 +132,11 @@ public class SoftLoginUseCaseShould {
             public void onMaxInvalidLoginAttemptsError(long enableLoginTime) {
                 fail("onMaxInvalidLoginAttemptsError");
             }
+
+            @Override
+            public void onServerNotAvailable(String message) {
+                fail("onServerNotAvailable");
+            }
         });
     }
 
@@ -127,6 +148,7 @@ public class SoftLoginUseCaseShould {
 
         SoftLoginUseCase softLoginUseCase = givenASoftLoginUseCase(true, lastValidPin);
 
+        mockWebServerRule.enqueueMockResponseFileName(200, API_AVAILABLE_OK);
         mockWebServerRule.enqueueMockResponseFileName(200, AUTH_SUCCESS);
 
         softLoginUseCase.execute(lastValidPin, new SoftLoginUseCase.Callback() {
@@ -149,6 +171,11 @@ public class SoftLoginUseCaseShould {
             public void onMaxInvalidLoginAttemptsError(long enableLoginTime) {
                 fail("onMaxInvalidLoginAttemptsError");
             }
+
+            @Override
+            public void onServerNotAvailable(String message) {
+                fail("onMaxInvalidLoginAttemptsError");
+            }
         });
     }
 
@@ -160,6 +187,7 @@ public class SoftLoginUseCaseShould {
 
         SoftLoginUseCase softLoginUseCase = givenASoftLoginUseCase(true, lastValidPin);
 
+        mockWebServerRule.enqueueMockResponseFileName(200, API_AVAILABLE_OK);
         mockWebServerRule.enqueueMockResponseFileName(200, AUTH_FAIL);
 
         softLoginUseCase.execute("1234567", new SoftLoginUseCase.Callback() {
@@ -182,6 +210,11 @@ public class SoftLoginUseCaseShould {
             public void onMaxInvalidLoginAttemptsError(long enableLoginTime) {
                 fail("onMaxInvalidLoginAttemptsError");
             }
+
+            @Override
+            public void onServerNotAvailable(String message) {
+                fail("onMaxInvalidLoginAttemptsError");
+            }
         });
     }
 
@@ -195,6 +228,7 @@ public class SoftLoginUseCaseShould {
         SoftLoginUseCase softLoginUseCase =
                 givenASoftLoginUseCase(invalidLoginAttempts, 0);
 
+        mockWebServerRule.enqueueMockResponseFileName(200, API_AVAILABLE_OK);
         mockWebServerRule.enqueueMockResponseFileName(200, AUTH_FAIL);
 
         softLoginUseCase.execute("1234567", new SoftLoginUseCase.Callback() {
@@ -216,6 +250,12 @@ public class SoftLoginUseCaseShould {
             @Override
             public void onMaxInvalidLoginAttemptsError(long enableLoginTime) {
                 Assert.assertTrue(true);
+            }
+
+
+            @Override
+            public void onServerNotAvailable(String message) {
+                fail("onMaxInvalidLoginAttemptsError");
             }
         });
     }
@@ -251,6 +291,11 @@ public class SoftLoginUseCaseShould {
             public void onMaxInvalidLoginAttemptsError(long enableLoginTime) {
                 Assert.assertTrue(true);
             }
+
+            @Override
+            public void onServerNotAvailable(String message) {
+                fail("onMaxInvalidLoginAttemptsError");
+            }
         });
     }
 
@@ -265,6 +310,7 @@ public class SoftLoginUseCaseShould {
                 givenASoftLoginUseCase(invalidLoginAttempts,
                         new Date().getTime() - DISABLE_LOGIN_BY_ATTEMPTS);
 
+        mockWebServerRule.enqueueMockResponseFileName(200, API_AVAILABLE_OK);
         mockWebServerRule.enqueueMockResponseFileName(200, AUTH_SUCCESS);
 
         softLoginUseCase.execute("1234", new SoftLoginUseCase.Callback() {
@@ -286,6 +332,12 @@ public class SoftLoginUseCaseShould {
             @Override
             public void onMaxInvalidLoginAttemptsError(long enableLoginTime) {
                 fail("onMaxLoginAttemptsReachedError");
+            }
+
+
+            @Override
+            public void onServerNotAvailable(String message) {
+                fail("onMaxInvalidLoginAttemptsError");
             }
         });
     }
@@ -327,9 +379,9 @@ public class SoftLoginUseCaseShould {
         IAuthenticationDataSource userAccountRemoteDataSource =
                 new AuthenticationWSDataSource(eReferralsAPIClient);
 
-
         IAuthenticationManager authenticationManager = new AuthenticationManager(
-                userAccountLocalDataSource, userAccountRemoteDataSource, userRepository);
+                userAccountLocalDataSource, userAccountRemoteDataSource, userRepository,
+                forgotPasswordDataSource, settingsRepository);
 
         when(connectivityManager.isDeviceOnline()).thenReturn(withConnection);
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2398  
* **Related pull-requests:** 

### :tophat: What is the goal?

Improve load time of the surveys on the list.

###   :gear: branches 
**app**:
       Origin: maintenance-refactor_from_listview_to_recyclerview Target: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

Refactor SurveysFragment to apply Model View presenter and load surveys by UseCase

### :boom: How can it be tested?

Load this database on a device with connect 1.4 and a device with this branch (69 surveys)
[EyeSeeTeaDB.db.zip](https://github.com/EyeSeeTea/pictureapp/files/2904047/EyeSeeTeaDB.db.zip)

**Use Case 1**:  The surveys load should be faster on this branch. 
**Use Case 2**:  The rendered data on surveys list should be equal on both versions.

I have recorded my screen with my tests [video](https://drive.google.com/file/d/1ebacFiKaLvd3igxaoMbkPippmVT0x52s/view?usp=sharing)

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots

