### PR TITLE
Maintenance show webview timeouts only if tab is visible

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -381,10 +381,10 @@ dependencies {
     compile "com.squareup:javapoet:${libs.javapoetVersion}"
 
     //DBFlow
-    apt "com.github.Raizlabs.DBFlow:dbflow-processor:${libs.dbFlowVersion}"
-    compile "com.github.Raizlabs.DBFlow:dbflow:${libs.dbFlowVersion}"
-    compile "com.github.Raizlabs.DBFlow:dbflow-core:${libs.dbFlowVersion}"
-    compile "com.github.Raizlabs.DBFlow:dbflow-sqlcipher:${libs.dbFlowVersion}"
+    apt "com.github.agrosner.dbflow:dbflow-processor:${libs.dbFlowVersion}"
+    compile "com.github.agrosner.dbflow:dbflow:${libs.dbFlowVersion}"
+    compile "com.github.agrosner.dbflow:dbflow-core:${libs.dbFlowVersion}"
+    compile "com.github.agrosner.dbflow:dbflow-sqlcipher:${libs.dbFlowVersion}"
     compile(project(path: ':bugshaker')) {
         exclude group: "com.google.android.gms"
     }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/fragments/WebViewFragment.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/fragments/WebViewFragment.java
@@ -20,10 +20,10 @@ import android.view.ViewGroup;
 import android.webkit.CookieManager;
 import android.webkit.CookieSyncManager;
 import android.webkit.WebView;
-import android.webkit.WebViewClient;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.eyeseetea.malariacare.DashboardActivity;
 import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.domain.boundary.executors.IDelayedMainExecutor;
@@ -185,6 +185,10 @@ public class WebViewFragment extends Fragment implements IDashboardFragment {
         }
     }
 
+    public String getUrl() {
+        return url;
+    }
+
     private void loadUrlInWebView(boolean shouldShowError) {
         if (mWebView != null) {
             ConnectivityManager cm = (ConnectivityManager) getActivity().getSystemService(
@@ -252,12 +256,29 @@ public class WebViewFragment extends Fragment implements IDashboardFragment {
         customWebViewClient.setErrorListener(new CustomWebViewClient.ErrorListener() {
             @Override
             public void onTimeoutError() {
-                // do what you want
-                showError(R.string.web_view_network_error);
+                if (isFragmentVisible()) {
+                    // do what you want
+                    showError(R.string.web_view_network_error);
+                }
             }
         });
 
         mWebView.setWebViewClient(customWebViewClient);
+    }
+
+    private boolean isFragmentVisible() {
+        boolean isVisible = false;
+
+        Fragment fragment = DashboardActivity.dashboardActivity.getCurrentFragment();
+
+        if (fragment != null && fragment instanceof WebViewFragment){
+            WebViewFragment webViewFragment = (WebViewFragment) fragment;
+
+            isVisible = webViewFragment.getUrl().equals(url);
+
+        }
+
+        return isVisible;
     }
 
     private void showHideWebView(boolean show) {

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/fragments/WebViewFragment.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/fragments/WebViewFragment.java
@@ -23,7 +23,6 @@ import android.webkit.WebView;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import org.eyeseetea.malariacare.DashboardActivity;
 import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.domain.boundary.executors.IDelayedMainExecutor;
@@ -43,11 +42,13 @@ public class WebViewFragment extends Fragment implements IDashboardFragment {
     public static final String TITLE = "title";
     public static final int COOL_DOWN_TIME = 60;
 
+    private enum WebViewStatus {NO_LOADED, SUCCESS, TIMEOUT}
+
     private String url;
     private int title;
     private WebView mWebView;
     private CustomTextView mErrorDemoText;
-    private boolean loadedFirstTime;
+    private WebViewStatus webViewStatus;
 
     private IDelayedMainExecutor delayedMainExecutor;
 
@@ -55,16 +56,22 @@ public class WebViewFragment extends Fragment implements IDashboardFragment {
     private TextView countdownTextView;
     private int activateRefreshTimeLeft = COOL_DOWN_TIME;
 
+    private boolean isVisible = false;
+
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
             Bundle savedInstanceState) {
+
+        webViewStatus = WebViewStatus.NO_LOADED;
+
         Log.d(TAG, "onCreateView");
         View view = inflater.inflate(R.layout.fragment_web_view,
                 container, false);
         delayedMainExecutor = new UIThreadExecutor();
         manageBundle(savedInstanceState);
         initViews(view);
+
         return view;
     }
 
@@ -73,6 +80,21 @@ public class WebViewFragment extends Fragment implements IDashboardFragment {
         getActivity().registerReceiver(connectionReceiver,
                 new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
         super.onStart();
+
+        Log.d(TAG, "onStart url: " + url);
+    }
+
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        Log.d(TAG, "onResume url: " + url);
+    }
+
+    public void changeVisibility(boolean isVisible) {
+        Log.d(TAG, "changeVisibility to " + isVisible + " onResume url: " + url);
+        this.isVisible = isVisible;
     }
 
     @Override
@@ -98,6 +120,8 @@ public class WebViewFragment extends Fragment implements IDashboardFragment {
     }
 
     private void refreshWebView() {
+        webViewStatus = WebViewStatus.NO_LOADED;
+        mWebView.loadUrl("about:blank");
         loadUrlInWebView(true);
 
         disableRefreshWebView();
@@ -143,6 +167,7 @@ public class WebViewFragment extends Fragment implements IDashboardFragment {
 
     @Override
     public void reloadData() {
+
     }
 
 
@@ -236,6 +261,7 @@ public class WebViewFragment extends Fragment implements IDashboardFragment {
     }
 
     private void executeOnWebAvailable() {
+        Log.d(TAG, "loading url: " + url);
         showHideWebView(true);
         mWebView.getSettings().setJavaScriptEnabled(true);
         mWebView.getSettings().setDomStorageEnabled(true);
@@ -248,7 +274,12 @@ public class WebViewFragment extends Fragment implements IDashboardFragment {
                 new CustomWebViewClient(timeoutMillis) {
                     @Override
                     public void onPageFinished(WebView view, String url) {
-                        loadedFirstTime = true;
+                        Log.d(TAG, "onPageFinished url: " + url);
+
+                        if (webViewStatus == WebViewStatus.NO_LOADED) {
+                            webViewStatus = WebViewStatus.SUCCESS;
+                        }
+
                         super.onPageFinished(view, url);
                     }
                 };
@@ -256,29 +287,19 @@ public class WebViewFragment extends Fragment implements IDashboardFragment {
         customWebViewClient.setErrorListener(new CustomWebViewClient.ErrorListener() {
             @Override
             public void onTimeoutError() {
-                if (isFragmentVisible()) {
+                webViewStatus = WebViewStatus.TIMEOUT;
+                Log.d(TAG, "onTimeoutError url: " + url);
+                if (isVisible) {
                     // do what you want
                     showError(R.string.web_view_network_error);
+                    Log.d(TAG, "showing onTimeoutError url: " + url);
+                } else {
+                    Log.d(TAG, "does not show onTimeoutError because fragment is not visible url: " + url);
                 }
             }
         });
 
         mWebView.setWebViewClient(customWebViewClient);
-    }
-
-    private boolean isFragmentVisible() {
-        boolean isVisible = false;
-
-        Fragment fragment = DashboardActivity.dashboardActivity.getCurrentFragment();
-
-        if (fragment != null && fragment instanceof WebViewFragment){
-            WebViewFragment webViewFragment = (WebViewFragment) fragment;
-
-            isVisible = webViewFragment.getUrl().equals(url);
-
-        }
-
-        return isVisible;
     }
 
     private void showHideWebView(boolean show) {
@@ -290,7 +311,7 @@ public class WebViewFragment extends Fragment implements IDashboardFragment {
         @Override
         public void onReceive(Context context, Intent intent) {
             if (ConnectivityStatus.isConnected(getActivity())) {
-                if (!loadedFirstTime) {
+                if (webViewStatus != WebViewStatus.SUCCESS ) {
                     loadValidUrl(true);
                 }
             }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/DashboardActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/DashboardActivityStrategy.java
@@ -199,6 +199,8 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
         } else {
             showStockFragment(activity, false);
         }
+
+        mDashboardActivity.setCurrentFragment(closeFragment);
     }
 
     @Override
@@ -319,6 +321,8 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
         } else {
             showFirstFragment();
         }
+
+        mDashboardActivity.setCurrentFragment(surveysFragment);
     }
 
     @Override
@@ -349,6 +353,8 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
         } else {
             showSecondFragment();
         }
+
+        mDashboardActivity.setCurrentFragment(openFragment);
     }
 
     @Override
@@ -405,6 +411,8 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
         }
         mDashboardActivity.replaceFragment(R.id.dashboard_charts_container, avFragment);
         avFragment.hideHeader();
+
+        mDashboardActivity.setCurrentFragment(avFragment);
     }
 
     @Override
@@ -555,6 +563,8 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
         } else {
             showAVFragment();
         }
+
+        mDashboardActivity.setCurrentFragment(statusFragment);
     }
 
     public void showEndSurveyMessage(SurveyDB surveyDB) {

--- a/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
@@ -342,12 +342,20 @@ public class DashboardActivity extends BaseActivity {
     }
 
 
+    private Fragment currentFragment;
+
+    public Fragment getCurrentFragment() {
+        return currentFragment;
+    }
+
     // Add the fragment to the activity, pushing this transaction
     // on to the back stack.
     public void replaceFragment(int layout, Fragment fragment) {
         FragmentTransaction ft = getFragmentTransaction();
         ft.replace(layout, fragment);
         ft.commit();
+
+        currentFragment = fragment;
     }
 
     @Override

--- a/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
@@ -56,6 +56,7 @@ import org.eyeseetea.malariacare.domain.usecase.RemoveSurveysInProgressUseCase;
 import org.eyeseetea.malariacare.factories.AuthenticationFactoryStrategy;
 import org.eyeseetea.malariacare.fragments.ReviewFragment;
 import org.eyeseetea.malariacare.fragments.SurveyFragment;
+import org.eyeseetea.malariacare.fragments.WebViewFragment;
 import org.eyeseetea.malariacare.layout.adapters.survey.DynamicTabAdapter;
 import org.eyeseetea.malariacare.layout.score.ScoreRegister;
 import org.eyeseetea.malariacare.layout.utils.LayoutUtils;
@@ -348,14 +349,27 @@ public class DashboardActivity extends BaseActivity {
         return currentFragment;
     }
 
+    public void setCurrentFragment(Fragment fragment) {
+        //TODO: with view pager this manual management of visibility would be no necessary
+        changeFragmentVisibilityFlag(currentFragment, false);
+        currentFragment = fragment;
+        changeFragmentVisibilityFlag(currentFragment, true);
+    }
+
     // Add the fragment to the activity, pushing this transaction
     // on to the back stack.
     public void replaceFragment(int layout, Fragment fragment) {
         FragmentTransaction ft = getFragmentTransaction();
         ft.replace(layout, fragment);
         ft.commit();
+    }
 
-        currentFragment = fragment;
+    private void changeFragmentVisibilityFlag(Fragment fragment, boolean isVisible) {
+        if (fragment != null && fragment instanceof WebViewFragment) {
+            WebViewFragment webViewFragment = (WebViewFragment) fragment;
+
+            webViewFragment.changeVisibility(isVisible);
+        }
     }
 
     @Override


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2408  
* **Related pull-requests:** 

### :tophat: What is the goal?

Do not show the timeout message if this web view is not visible

###   :gear: branches 
**app**:
       Origin: maintenance-show_webview_timeouts_only_if_tab_is_visible Target: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?
I have had problems to apply simple solutions for the use of deprecated fragments and our use of fragment and tabs with all fragment loaded.

I have tried several approaches but finally for all the above mentioned I had to use the option to use DashboardActivity in a static way. It is not my preferred solution but it is the only one that has worked.

I save de current fragment when a fragment replacement occurs and then verify from WebViewFragment before to show timeout message against this saved current fragment in DasboardActivity to know if It's visible.

### :boom: How can it be tested?

Change web_view_timeout_millis in donottranslate.xml to lower value

**Use Case 1**:  Start the app and timeout message should only appear if the current tab is the WebViewFragment

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots