### PR TITLE
Maintenance login dropdown color contrast lower versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -381,10 +381,10 @@ dependencies {
     compile "com.squareup:javapoet:${libs.javapoetVersion}"
 
     //DBFlow
-    apt "com.github.Raizlabs.DBFlow:dbflow-processor:${libs.dbFlowVersion}"
-    compile "com.github.Raizlabs.DBFlow:dbflow:${libs.dbFlowVersion}"
-    compile "com.github.Raizlabs.DBFlow:dbflow-core:${libs.dbFlowVersion}"
-    compile "com.github.Raizlabs.DBFlow:dbflow-sqlcipher:${libs.dbFlowVersion}"
+    apt "com.github.agrosner.dbflow:dbflow-processor:${libs.dbFlowVersion}"
+    compile "com.github.agrosner.dbflow:dbflow:${libs.dbFlowVersion}"
+    compile "com.github.agrosner.dbflow:dbflow-core:${libs.dbFlowVersion}"
+    compile "com.github.agrosner.dbflow:dbflow-sqlcipher:${libs.dbFlowVersion}"
     compile(project(path: ':bugshaker')) {
         exclude group: "com.google.android.gms"
     }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/LoginActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/LoginActivityStrategy.java
@@ -197,7 +197,7 @@ public class LoginActivityStrategy extends ALoginActivityStrategy {
             return;
         }
         ArrayAdapter serversListAdapter = new ArrayAdapter<>(loginActivity.getBaseContext(),
-                android.R.layout.simple_spinner_item, serverList);
+                R.layout.item_server, serverList);
         serverSpinner.setAdapter(serversListAdapter);
         serverSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override

--- a/app/src/ereferrals/res/layout/item_server.xml
+++ b/app/src/ereferrals/res/layout/item_server.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.eyeseetea.sdk.presentation.views.CustomTextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/text1"
+    style="@style/SpinnerStyle"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:ellipsize="marquee"
+    android:gravity="left"
+    android:textColor="@color/text_first_color"
+    android:singleLine="true"
+    android:textAlignment="gravity"/>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2407  
* **Related pull-requests:** 

### :tophat: What is the goal?

Fix text appearance on server spinner popup in login for lower versions.

###   :gear: branches 
**app**:
       Origin: maintenance-show_webview_timeouts_only_if_tab_is_visible Target: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?
I have tried to solve this bug with styles but does not work.

I have used finally custom layout for items instead of using the Android layout.

### :boom: How can it be tested?

**Use Case 1**:  Start the app with an Android 5.1 and server dropdown color contrast should be ok

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots