### PR TITLE
Maintenance change soft login timeout

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'io.fabric.tools:gradle:1.+'
+        classpath 'io.fabric.tools:gradle:1.27.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.google.gms:google-services:3.0.0'

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/exporter/eReferralsAPIClient.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/exporter/eReferralsAPIClient.java
@@ -50,21 +50,23 @@ public class eReferralsAPIClient {
     private ApiClientRetrofit mApiClientRetrofit;
     private OkHttpClient mOkHttpClient;
     public String mBaseAddress;
-    private final int DEFAULT_TIMEOUT = 50000;
+    private static final int DEFAULT_TIMEOUT = 50000;
 
     public eReferralsAPIClient(String baseAddress) throws IllegalArgumentException {
+        this(baseAddress,DEFAULT_TIMEOUT);
+    }
+
+    public eReferralsAPIClient(String baseAddress, int timeoutMillis) throws IllegalArgumentException {
         if(baseAddress.equals(Credentials.createDemoCredentials().getServerURL())){
             return;
         }
         mBaseAddress = baseAddress;
         mContext = PreferencesState.getInstance().getContext();
 
-        initializeDependencies(DEFAULT_TIMEOUT);
+        initializeDependencies(timeoutMillis);
     }
 
     private void initializeDependencies(int timeoutMillis) {
-        timeoutMillis += DEFAULT_TIMEOUT;
-
         HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor();
         interceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
 

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/usecase/SoftLoginUseCase.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/usecase/SoftLoginUseCase.java
@@ -13,6 +13,8 @@ import org.eyeseetea.malariacare.domain.exception.ActionNotAllowed;
 import org.eyeseetea.malariacare.domain.exception.AvailableApiException;
 import org.eyeseetea.malariacare.domain.exception.InvalidCredentialsException;
 
+import java.net.SocketTimeoutException;
+
 public class SoftLoginUseCase implements UseCase {
     private final IConnectivityManager connectivityManager;
     private final IAuthenticationManager authenticationManager;
@@ -71,6 +73,8 @@ public class SoftLoginUseCase implements UseCase {
                                     notifyInvalidPassword();
                                 } else if (throwable instanceof AvailableApiException) {
                                     notifyServerNotAvailable(throwable.getMessage());
+                                } else if (throwable instanceof SocketTimeoutException) {
+                                    verifyAgainstLastValidCredentials(lastValidCredentials);
                                 } else {
                                     notifyNetworkError();
                                 }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/factories/AuthenticationFactoryStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/factories/AuthenticationFactoryStrategy.java
@@ -136,7 +136,7 @@ public class AuthenticationFactoryStrategy extends AAuthenticationFactory {
     }
 
     public SoftLoginUseCase getSoftLoginUseCase(Context context) {
-        int remoteTimeoutSoftLogin = 10;
+        int remoteTimeoutSoftLogin = 5000;
 
         IConnectivityManager connectivityManager = getConnectivityManager(context);
         IAuthenticationManager authenticationManager =

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/factories/AuthenticationFactoryStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/factories/AuthenticationFactoryStrategy.java
@@ -85,6 +85,22 @@ public class AuthenticationFactoryStrategy extends AAuthenticationFactory {
                 new SettingsDataSource(context));
     }
 
+    private IAuthenticationManager getAuthenticationManager(Context context, int remoteTimeoutMillis) {
+        IAuthenticationDataSource userAccountLocalDataSource =
+                new AuthenticationLocalDataSource(context);
+
+        eReferralsAPIClient eReferralsAPIClient = new eReferralsAPIClient(
+                PreferencesEReferral.getWSURL(), remoteTimeoutMillis);
+
+        IAuthenticationDataSource userAccountRemoteDataSource =
+                new AuthenticationWSDataSource(eReferralsAPIClient);
+
+        return new AuthenticationManager(userAccountLocalDataSource, userAccountRemoteDataSource,
+                new UserAccountDataSource(),
+                new ForgotPasswordWSDataSource(context),
+                new SettingsDataSource(context));
+    }
+
     public ForgotPasswordUseCase getForgotPasswordUseCase(Context context) {
         IAuthenticationManager authenticationManager = getAuthenticationManager(context);
         ISettingsRepository settingsRepository = new SettingsDataSource(context);
@@ -120,8 +136,11 @@ public class AuthenticationFactoryStrategy extends AAuthenticationFactory {
     }
 
     public SoftLoginUseCase getSoftLoginUseCase(Context context) {
+        int remoteTimeoutSoftLogin = 10;
+
         IConnectivityManager connectivityManager = getConnectivityManager(context);
-        IAuthenticationManager authenticationManager = getAuthenticationManager(context);
+        IAuthenticationManager authenticationManager =
+                getAuthenticationManager(context,remoteTimeoutSoftLogin);
         ICredentialsRepository credentialsLocalDataSource = getCredentialsRepository();
         IInvalidLoginAttemptsRepository invalidLoginAttemptsRepository =
                 getInvalidLoginAttemptsRepository();


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2406  
* **Related pull-requests:** 

### :tophat: What is the goal?

- Assign to soft login against the server a timeout of 5 seconds
- when a timeout is thrown during a soft login then the soft login is verified against local

###   :gear: branches 
**app**:
       Origin: maintenance-change_soft_login_timeout Target: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

- I have added a new timeout parameter to eReferralsApiclient and when this one is configured to soft login, receive 5 seconds as the timeout.
- I have refactored SoftloginUseCase to verify against last valid credentials when a timeout is thrown from eReferralsApiclient.
- I have added a new test to verify this new logic

### :boom: How can it be tested?

1 - Change build variant to ereferralsStaging and execute all unit and instrumentation tests.
2 - Change build variant to ereferralsDebug and remove the app in the device
3 - execute app and verify manually the next use cases:

Change current remoteTimeoutSoftLogin from 5000 milliseconds to lower (getSoftLoginUseCase method in AuthenticationFactoryStrategy).

**Use Case 1**:  start the app realize full login and provoke one action to soft login to appear, for example, close the app and start again. The soft login should work verifying against local. 

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots