### PR TITLE
Maintenance push service crash android 8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'io.fabric.tools:gradle:1.+'
+        classpath 'io.fabric.tools:gradle:1.27.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.google.gms:google-services:3.0.0'

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/exporter/WSPushController.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/exporter/WSPushController.java
@@ -1,5 +1,6 @@
 package org.eyeseetea.malariacare.data.sync.exporter;
 
+
 import android.content.Context;
 import android.util.Log;
 
@@ -118,7 +119,9 @@ public class WSPushController implements IPushController {
     }
 
     private void pushSurveys() {
-        mEReferralsAPIClient.setTimeoutMillis(getTimeout(mSurveys.size()));
+        mEReferralsAPIClient.setTimeoutMillis(
+                eReferralsAPIClient.DEFAULT_TIMEOUT + getTimeout(mSurveys.size()));
+
         SurveyContainerWSObject surveyContainerWSObject =
                 mConvertToWSVisitor.getSurveyContainerWSObject();
         mEReferralsAPIClient.pushSurveys(surveyContainerWSObject,

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/exporter/eReferralsAPIClient.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/exporter/eReferralsAPIClient.java
@@ -50,7 +50,7 @@ public class eReferralsAPIClient {
     private ApiClientRetrofit mApiClientRetrofit;
     private OkHttpClient mOkHttpClient;
     public String mBaseAddress;
-    private static final int DEFAULT_TIMEOUT = 50000;
+    public static final int DEFAULT_TIMEOUT = 50000;
 
     public eReferralsAPIClient(String baseAddress) throws IllegalArgumentException {
         this(baseAddress,DEFAULT_TIMEOUT);
@@ -100,7 +100,7 @@ public class eReferralsAPIClient {
     }
 
     public void setTimeoutMillis(int timeoutMillis) {
-        initializeDependencies(timeoutMillis);
+        initializeDependencies( timeoutMillis);
     }
 
     public void pushSurveys(SurveyContainerWSObject surveyContainerWSObject,

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/DashboardActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/DashboardActivityStrategy.java
@@ -166,9 +166,10 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
     }
 
     private void launchPush() {
+
         Intent pushIntent = new Intent(mDashboardActivity, PushService.class);
         pushIntent.putExtra(SurveyService.SERVICE_METHOD, PushService.PENDING_SURVEYS_ACTION);
-        mDashboardActivity.startService(pushIntent);
+        PushService.enqueueWork(mDashboardActivity, pushIntent);
     }
 
     private void showToast(@StringRes int text) {
@@ -209,7 +210,8 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
             public void onSuccess(Settings setting) {
                 String webViewFragmentUrl = getWebviewUrl(R.string.url_closed_fragment);
                 String url = getFormattedUrl(setting.getWebUrl(), webViewFragmentUrl);
-                loadFragment(url, closeFragment, R.id.dashboard_stock_container, R.string.tab_tag_improve);
+                loadFragment(url, closeFragment, R.id.dashboard_stock_container,
+                        R.string.tab_tag_improve);
             }
         });
         return isMoveToLeft;
@@ -323,7 +325,7 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
 
     @Override
     public void reloadFirstFragmentHeader() {
-        if(!DashboardActivity.dashboardActivity.isSurveyFragmentActive()) {
+        if (!DashboardActivity.dashboardActivity.isSurveyFragmentActive()) {
             surveysFragment.reloadHeader(mDashboardActivity);
         }
     }
@@ -336,7 +338,8 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
             public void onSuccess(Settings setting) {
                 String webViewFragmentUrl = getWebviewUrl(R.string.url_open_fragment);
                 String url = getFormattedUrl(setting.getWebUrl(), webViewFragmentUrl);
-                loadFragment(url, openFragment, R.id.dashboard_completed_container, R.string.tab_tag_assess);
+                loadFragment(url, openFragment, R.id.dashboard_completed_container,
+                        R.string.tab_tag_assess);
             }
         });
     }
@@ -359,7 +362,8 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
             public void onSuccess(Settings setting) {
                 String webViewFragmentUrl = getWebviewUrl(R.string.url_status_fragment);
                 String url = getFormattedUrl(setting.getWebUrl(), webViewFragmentUrl);
-                loadFragment(url, statusFragment, R.id.dashboard_av_container, R.string.tab_tag_monitor);
+                loadFragment(url, statusFragment, R.id.dashboard_av_container,
+                        R.string.tab_tag_monitor);
             }
         });
     }
@@ -383,9 +387,9 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
     }
 
     private String getWebviewUrl(int valueId) {
-        if(credentials!=null && credentials.isDemoCredentials()){
+        if (credentials != null && credentials.isDemoCredentials()) {
             return null;
-        } else{
+        } else {
             return mDashboardActivity.getString(valueId);
         }
     }
@@ -531,19 +535,23 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
         externalVoucherSenderResultTreatment(requestCode, resultCode, data);
     }
 
-    private void externalVoucherSenderResultTreatment(int requestCode, int resultCode, Intent data) {
-        IExternalVoucherRegistry elementController = new ElementController(DashboardActivity.dashboardActivity);
-        TreatExternalAppResultUseCase treatExternalAppResultUseCase = new TreatExternalAppResultUseCase(elementController, new IExternalVoucherRegistry.Callback() {
-            @Override
-            public void onSuccess() {
-                Log.d(TAG, "User created");
-            }
+    private void externalVoucherSenderResultTreatment(int requestCode, int resultCode,
+            Intent data) {
+        IExternalVoucherRegistry elementController = new ElementController(
+                DashboardActivity.dashboardActivity);
+        TreatExternalAppResultUseCase treatExternalAppResultUseCase =
+                new TreatExternalAppResultUseCase(elementController,
+                        new IExternalVoucherRegistry.Callback() {
+                            @Override
+                            public void onSuccess() {
+                                Log.d(TAG, "User created");
+                            }
 
-            @Override
-            public void onError() {
-                Log.d(TAG, "User is not created");
-            }
-        });
+                            @Override
+                            public void onError() {
+                                Log.d(TAG, "User is not created");
+                            }
+                        });
         treatExternalAppResultUseCase.execute(requestCode, resultCode, data);
     }
 
@@ -561,14 +569,16 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
         if (surveyDB != null && !noIssueVoucher(surveyDB) && !hasPhone(surveyDB)) {
             final String voucherUId = surveyDB.getVoucherUid();
 
-            GetSettingsUseCase getSettingsUseCase = new GetSettingsUseCase(new UIThreadExecutor(), new AsyncExecutor(),
+            GetSettingsUseCase getSettingsUseCase = new GetSettingsUseCase(new UIThreadExecutor(),
+                    new AsyncExecutor(),
                     new SettingsDataSource(mDashboardActivity.getBaseContext()));
             getSettingsUseCase.execute(new GetSettingsUseCase.Callback() {
                 @Override
                 public void onSuccess(Settings setting) {
                     DialogInterface.OnClickListener onClickListener = null;
-                    if(setting.isElementActive()){
-                        onClickListener = createOnClickListenerToSendVoucherToExternalApp(voucherUId, mDashboardActivity);
+                    if (setting.isElementActive()) {
+                        onClickListener = createOnClickListenerToSendVoucherToExternalApp(
+                                voucherUId, mDashboardActivity);
                     }
 
                     mDashboardActivity.showException(mDashboardActivity, "", String.format(
@@ -580,21 +590,24 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
     }
 
     @NonNull
-    private DialogInterface.OnClickListener createOnClickListenerToSendVoucherToExternalApp(final String voucherUId, final Context context) {
+    private DialogInterface.OnClickListener createOnClickListenerToSendVoucherToExternalApp(
+            final String voucherUId, final Context context) {
         return new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialogInterface, int i) {
                 IExternalVoucherRegistry elementController = new ElementController(context);
                 AsyncExecutor mAsyncExecutor = new AsyncExecutor();
                 UIThreadExecutor mMainExecutor = new UIThreadExecutor();
-                SendToExternalAppPaperVoucherUseCase elementSentVoucherUseCase = new SendToExternalAppPaperVoucherUseCase(mMainExecutor, mAsyncExecutor,
-                        elementController, new IExternalVoucherRegistry.SenderCallback() {
-                    @Override
-                    public void onNotInstalledApp() {
-                        Toast.makeText(context,
-                                translate(R.string.element_not_installed), Toast.LENGTH_LONG).show();
-                    }
-                });
+                SendToExternalAppPaperVoucherUseCase elementSentVoucherUseCase =
+                        new SendToExternalAppPaperVoucherUseCase(mMainExecutor, mAsyncExecutor,
+                                elementController, new IExternalVoucherRegistry.SenderCallback() {
+                            @Override
+                            public void onNotInstalledApp() {
+                                Toast.makeText(context,
+                                        translate(R.string.element_not_installed),
+                                        Toast.LENGTH_LONG).show();
+                            }
+                        });
                 elementSentVoucherUseCase.execute(voucherUId);
             }
         };

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
             android:exported="false" />
         <service
             android:name=".services.PushService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false" />
 
         <meta-data

--- a/app/src/main/java/org/eyeseetea/malariacare/receivers/AlarmPushReceiver.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/receivers/AlarmPushReceiver.java
@@ -62,7 +62,8 @@ public class AlarmPushReceiver extends BroadcastReceiver {
 
         Intent pushIntent = new Intent(context, PushService.class);
         pushIntent.putExtra(SurveyService.SERVICE_METHOD, PushService.PENDING_SURVEYS_ACTION);
-        context.startService(pushIntent);
+
+        PushService.enqueueWork(context, pushIntent);
     }
 
     public static void setPushAlarm(Context context) {

--- a/app/src/main/java/org/eyeseetea/malariacare/services/PushService.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/services/PushService.java
@@ -20,8 +20,10 @@
 
 package org.eyeseetea.malariacare.services;
 
-import android.app.IntentService;
+import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.NonNull;
+import android.support.v4.app.JobIntentService;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
@@ -31,7 +33,7 @@ import org.eyeseetea.malariacare.services.strategies.PushServiceStrategy;
 /**
  * A service that runs pushing process for pending surveys.
  */
-public class PushService extends IntentService {
+public class PushService extends JobIntentService {
 
     /**
      * Constant added to the intent in order to reuse the service for different 'methods'
@@ -51,42 +53,14 @@ public class PushService extends IntentService {
 
     PushServiceStrategy mPushServiceStrategy = new PushServiceStrategy(this);
 
-    /**
-     * Constructor required due to a error message in AndroidManifest.xml if it is not present
-     */
-    public PushService() {
-        super(PushService.class.getSimpleName());
-        Log.d(TAG, "PushService() register in Dhis2Application bus");
-    }
+    public static final int JOB_ID = 1;
 
-    /**
-     * Creates an IntentService. Invoked by your subclass's constructor.
-     *
-     * @param name Used to name the worker thread, important only for debugging.
-     */
-    public PushService(String name) {
-        super(name);
-        Log.d(TAG, "PushService(name) constructor");
-    }
-
-    public static void reloadDashboard() {
-        Intent surveysIntent = new Intent(PreferencesState.getInstance().getContext(),
-                SurveyService.class);
-        surveysIntent.putExtra(SurveyService.SERVICE_METHOD, SurveyService.RELOAD_DASHBOARD_ACTION);
-        PreferencesState.getInstance().getContext().startService(surveysIntent);
-        Intent broadcastIntent = new Intent(SurveyService.RELOAD_DASHBOARD_ACTION);
-        LocalBroadcastManager.getInstance(
-                PreferencesState.getInstance().getContext()).sendBroadcast(broadcastIntent);
+    public static void enqueueWork(Context context, Intent work) {
+        enqueueWork(context, PushService.class, JOB_ID, work);
     }
 
     @Override
-    public void onDestroy() {
-        Log.d(TAG, "onDestroy");
-        super.onDestroy();
-    }
-
-    @Override
-    protected void onHandleIntent(Intent intent) {
+    protected void onHandleWork(@NonNull Intent intent) {
         //Ignore wrong actions
         if (!PENDING_SURVEYS_ACTION.equals(intent.getStringExtra(SERVICE_METHOD))) {
             return;
@@ -99,6 +73,12 @@ public class PushService extends IntentService {
         mPushServiceStrategy.push();
     }
 
+    @Override
+    public void onDestroy() {
+        Log.d(TAG, "onDestroy");
+        super.onDestroy();
+    }
+
     public void onPushFinished() {
         reloadDashboard();
     }
@@ -107,5 +87,16 @@ public class PushService extends IntentService {
         PreferencesState.getInstance().setPushInProgress(false);
         Log.e(TAG, "onPushFinished error: " + message);
     }
+
+    public static void reloadDashboard() {
+        Intent surveysIntent = new Intent(PreferencesState.getInstance().getContext(),
+                SurveyService.class);
+        surveysIntent.putExtra(SurveyService.SERVICE_METHOD, SurveyService.RELOAD_DASHBOARD_ACTION);
+        PreferencesState.getInstance().getContext().startService(surveysIntent);
+        Intent broadcastIntent = new Intent(SurveyService.RELOAD_DASHBOARD_ACTION);
+        LocalBroadcastManager.getInstance(
+                PreferencesState.getInstance().getContext()).sendBroadcast(broadcastIntent);
+    }
+
 
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/services/PushService.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/services/PushService.java
@@ -89,14 +89,21 @@ public class PushService extends JobIntentService {
     }
 
     public static void reloadDashboard() {
-        Intent surveysIntent = new Intent(PreferencesState.getInstance().getContext(),
-                SurveyService.class);
-        surveysIntent.putExtra(SurveyService.SERVICE_METHOD, SurveyService.RELOAD_DASHBOARD_ACTION);
-        PreferencesState.getInstance().getContext().startService(surveysIntent);
+        try{
+            Intent surveysIntent = new Intent(PreferencesState.getInstance().getContext(),
+                    SurveyService.class);
+            surveysIntent.putExtra(SurveyService.SERVICE_METHOD, SurveyService.RELOAD_DASHBOARD_ACTION);
+            PreferencesState.getInstance().getContext().startService(surveysIntent);
+        } catch (Exception e){
+            //From Android 8 versions, start services in background has limitations and
+            //can throw errors. How SurveyService only has sense in foreground
+            //simply catch error. On the future we should not use spervice to load surveys
+
+            Log.d(TAG, "Error to start service to load surveys from background");
+        }
+
         Intent broadcastIntent = new Intent(SurveyService.RELOAD_DASHBOARD_ACTION);
         LocalBroadcastManager.getInstance(
                 PreferencesState.getInstance().getContext()).sendBroadcast(broadcastIntent);
     }
-
-
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2380 
* **Related pull-requests:** 

### :tophat: What is the goal?

Fix push service bugs when the app is on the background.

###   :gear: branches 
**app**:
       Origin: maintenance-push_service_crash_android_8 Target: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?
From Android 8 background service has limitations and jobscheduler should be used.
Support library added a new service called JobIntentService that manage this logic and I used it.

https://developer.android.com/about/versions/oreo/background
https://developer.android.com/reference/android/support/v4/app/JobIntentService.html

### :boom: How can it be tested?

**Use Case 1**:  Create a new survey and click on start push button in the toolbar, the push should be realized successfully.
**Use Case 2**:  Create a new survey and wait until push start in the toolbar, the push should be realized successfully.
**Use Case 3**:  Send the app to background starting a new app, the push service should be invoked indefinitely without bugs.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots