### PR TITLE
Fix bug getting webview url from preferences

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/database/datasources/SettingsDataSource.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/database/datasources/SettingsDataSource.java
@@ -151,7 +151,7 @@ public class SettingsDataSource implements ISettingsRepository {
     }
 
     private String getWebUrl() {
-        return getPreference(context, R.string.web_view_name, R.string.base_web_view_url);
+        return getPreference(context, R.string.web_view_url, R.string.base_web_view_url);
     }
 
     private String getWSServerUrl() {


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2415  
* **Related pull-requests:** 

### :tophat: What is the goal?

Alpha tester report

The app seems to always use:
https://apps.psi-mis.org/connect/
even if the settings page shows something else.

The easiest way to test that is to edit the WebURL in the testing page (to an invalid url for instance) and try to load one of the embedded pages.
Here it was loading successfully what seemed to be https://apps.psi-mis.org/connect/.

If we select the training environment at login time, the url in settings is:
https://apps.psi-mis.org/connect-train/
but it is not the page loaded.

###   :gear: branches 
**app**:
       Origin: maintenance/web_url_is_not_properly_used Target: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

After many tests, I have found the problem is retrieving saving preference webUrl. 

### :boom: How can it be tested?

**Use Case 1**:  From login use train server and to enter in dashboard,  the logcat should show traces the url loaded in web views and this one should be https://apps.psi-mis.org/connect-train/

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots