### PR TITLE
Maintenance/jump to drop down and new jump settings

### DIFF
--- a/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/services/PushServiceShould.java
+++ b/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/services/PushServiceShould.java
@@ -148,7 +148,7 @@ public class PushServiceShould {
         when(mProgramRepository.getUserProgram()).thenReturn(new Program("code","testProgramId"));
         Settings settings = new Settings("en", "en", null, false, false, false,
                 "test", "test", mockWebServerRule.getMockServer().getBaseEndpoint(), null, null,
-                null, null, false, false, "1.0");
+                null, null, false, false, "1.0",true);
         when(mSettingsRepository.getSettings()).thenReturn(settings);
         ConvertToWSVisitor mConvertToWSVisitor = new ConvertToWSVisitor(deviceDataSource, mCredentialsRepository, mSettingsRepository, appInfoDataSource,
                 mProgramRepository, new CountryVersionLocalDataSource());

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/database/datasources/SettingsDataSource.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/database/datasources/SettingsDataSource.java
@@ -42,10 +42,12 @@ public class SettingsDataSource implements ISettingsRepository {
         String wsVersion = getWSVersion();
         boolean isSoftLoginRequired = getSoftLoginRequired();
         boolean isPullRequired = getPullRequired();
+        boolean isSurveyJumpingActive = getSurveyJumping();
+
         return new Settings(systemLanguage, currentLanguage, getMediaListMode(), canDownloadMedia,
                 isElementActive, isMetadataUpdateActive, user, pass, wsServerUrl,
                 webUrl, fontSize, programUrl, programEndPoint, isSoftLoginRequired, isPullRequired,
-                wsVersion);
+                wsVersion,isSurveyJumpingActive);
     }
 
     private String loadPass() {
@@ -81,6 +83,7 @@ public class SettingsDataSource implements ISettingsRepository {
         saveProgramEndPoint(settings.getProgramEndPoint());
         saveSoftLoginRequired(settings.isSoftLoginRequired());
         savePullRequired(settings.isPullRequired());
+        saveSurveyJumping(settings.isSurveyJumpingActive());
     }
 
     private MediaListMode getMediaListMode() {
@@ -191,8 +194,16 @@ public class SettingsDataSource implements ISettingsRepository {
         return getBooleanPreference(context, R.string.pull_required, false);
     }
 
+    private boolean getSurveyJumping() {
+        return getBooleanPreference(context, R.string.preference_jumping_survey_views_key, true);
+    }
+
     private void savePullRequired(boolean isRequired) {
         saveBooleanPreference(context, R.string.pull_required, isRequired);
+    }
+
+    private void saveSurveyJumping(boolean isActive) {
+        saveBooleanPreference(context, R.string.preference_jumping_survey_views_key, isActive);
     }
 
     private Boolean getBooleanPreference(Context context, int stringId, Boolean defaultBool) {

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/entity/Settings.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/entity/Settings.java
@@ -24,12 +24,14 @@ public class Settings {
     private boolean softLoginRequired;
     private boolean pullRequired;
     private String wsVersion;
+    private boolean surveyJumpingActive;
 
     public Settings(String systemLanguage, String currentLanguage,
             MediaListMode mediaListMode, boolean canDownloadWith3G, boolean isElementActive,
                     boolean isMetadataUpdateActive, String user, String pass, String wsServerUrl,
             String webUrl, String fontSize, String programUrl, String programEndPoint,
-            boolean softLoginRequired, boolean pullRequired, String wsVersion) {
+            boolean softLoginRequired, boolean pullRequired, String wsVersion,
+            boolean surveyJumpingActive) {
         this.systemLanguage = required(systemLanguage, "systemLanguage is required");
         this.currentLanguage = currentLanguage;
         this.mediaListMode = mediaListMode;
@@ -46,6 +48,7 @@ public class Settings {
         this.wsVersion = wsVersion;
         this.softLoginRequired = softLoginRequired;
         this.pullRequired = pullRequired;
+        this.surveyJumpingActive = surveyJumpingActive;
     }
 
     public String getLanguage() {
@@ -148,5 +151,13 @@ public class Settings {
 
     public void changePullRequired(boolean isRequired) {
         pullRequired = isRequired;
+    }
+
+    public boolean isSurveyJumpingActive() {
+        return surveyJumpingActive;
+    }
+
+    public void setSurveyJumpingActive(boolean surveyJumpingActive) {
+        this.surveyJumpingActive = surveyJumpingActive;
     }
 }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/layout/adapters/survey/strategies/DynamicTabAdapterStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/layout/adapters/survey/strategies/DynamicTabAdapterStrategy.java
@@ -13,7 +13,10 @@ import org.eyeseetea.malariacare.data.database.model.QuestionDB;
 import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.data.database.utils.Session;
+import org.eyeseetea.malariacare.domain.entity.Settings;
 import org.eyeseetea.malariacare.domain.entity.Validation;
+import org.eyeseetea.malariacare.domain.usecase.GetSettingsUseCase;
+import org.eyeseetea.malariacare.factories.SettingsFactory;
 import org.eyeseetea.malariacare.layout.adapters.survey.DynamicTabAdapter;
 import org.eyeseetea.malariacare.strategies.UIMessagesStrategy;
 import org.eyeseetea.malariacare.utils.Constants;
@@ -24,8 +27,19 @@ import java.util.List;
 
 public class DynamicTabAdapterStrategy extends ADynamicTabAdapterStrategy {
 
-    public DynamicTabAdapterStrategy(DynamicTabAdapter dynamicTabAdapter) {
+    private boolean jumpingActive;
+
+
+    public DynamicTabAdapterStrategy(DynamicTabAdapter dynamicTabAdapter, boolean jumpingActive) {
         super(dynamicTabAdapter);
+
+        this.jumpingActive = jumpingActive;
+    }
+
+
+    @Override
+    public void setJumpingNextQuestionActive( CommonQuestionView questionView) {
+        questionView.setJumpingNextQuestionActive(jumpingActive);
     }
 
     @Override

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SurveyFragmentStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/SurveyFragmentStrategy.java
@@ -10,8 +10,11 @@ import org.eyeseetea.malariacare.data.database.model.QuestionDB;
 import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.data.database.model.ValueDB;
 import org.eyeseetea.malariacare.data.database.utils.Session;
+import org.eyeseetea.malariacare.domain.entity.Settings;
 import org.eyeseetea.malariacare.domain.entity.intent.Auth;
 import org.eyeseetea.malariacare.domain.usecase.GetAuthUseCase;
+import org.eyeseetea.malariacare.domain.usecase.GetSettingsUseCase;
+import org.eyeseetea.malariacare.factories.SettingsFactory;
 import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
 import org.eyeseetea.malariacare.presentation.executors.UIThreadExecutor;
 import org.eyeseetea.malariacare.utils.Constants;
@@ -102,6 +105,18 @@ public class SurveyFragmentStrategy {
             @Override
             public void onGetAuth(Auth auth) {
                 callback.loadIsSurveyCreatedInOtherApp(auth!=null);
+            }
+        });
+    }
+
+    public static void isSurveyJumpingActive (
+            final ASurveyFragmentStrategy.GetSurveyJumpingCallback callback,
+            Context context){
+        GetSettingsUseCase getSettingsUseCase = new SettingsFactory().getSettingsUseCase(context);
+        getSettingsUseCase.execute(new GetSettingsUseCase.Callback() {
+            @Override
+            public void onSuccess(Settings settings) {
+                callback.onSuccess(settings.isSurveyJumpingActive());
             }
         });
     }

--- a/app/src/ereferrals/res/values-ne/strings.xml
+++ b/app/src/ereferrals/res/values-ne/strings.xml
@@ -978,14 +978,13 @@
 <string name="production">उत्पादन</string>
 <string name="training">प्रशिक्षण</string>
 <string name="custom">अनुकूलन</string>
-
-    <string name="splash_progress_init_db">डेटाबेस सुरू गर्दै ...</string>
-    <string name="splash_progress_downloading_languages">वर्तमान भाषा सर्तहरू डाउनलोड गर्नुहोस् ...</string>
-    <string name="splash_progress_executing_maintenance_task">रखरखाव कार्य कार्यान्वयन गर्दै ...</string>
-
-    <string name="pull_dialog_progress_generic_message">मेटाडेटा अपडेट गर्दै …</string>
-    <string name="push_invalid_credentials">हामीले फेला पारेको छ कि पिनले सर्भरमा परिवर्तन गरेको छ, कृपया पिन फेरि सम्मिलित गर्नुहोस्</string>
-
-    <string name="web_view_network_error">वेब पेज लोड गर्दा नेटवर्क समस्याहरू छन्</string>
-    <string name="push_network_error">प्रक्रिया प्रक्रियामा सञ्जाल समस्याहरू छन्</string>
+<string name="splash_progress_init_db">डेटाबेस सुरू गर्दै ...</string>
+<string name="splash_progress_downloading_languages">वर्तमान भाषा सर्तहरू डाउनलोड गर्नुहोस् ...</string>
+<string name="splash_progress_executing_maintenance_task">रखरखाव कार्य कार्यान्वयन गर्दै ...</string>
+<string name="pull_dialog_progress_generic_message">मेटाडेटा अपडेट गर्दै …</string>
+<string name="push_invalid_credentials">हामीले फेला पारेको छ कि पिनले सर्भरमा परिवर्तन गरेको छ, कृपया पिन फेरि सम्मिलित गर्नुहोस्</string>
+<string name="web_view_network_error">वेब पेज लोड गर्दा नेटवर्क समस्याहरू छन्</string>
+<string name="push_network_error">प्रक्रिया प्रक्रियामा सञ्जाल समस्याहरू छन्</string>
+<string name="preference_jumping_survey_views_title">सर्वेक्षणमा जम्पिङ</string>
+<string name="preference_jumping_survey_views_summary">सर्वेक्षणमा हेराइहरू बीचमा जम्पिङ सक्रिय गर्नुहोस्</string>
 </resources>

--- a/app/src/ereferrals/res/values-pt/strings.xml
+++ b/app/src/ereferrals/res/values-pt/strings.xml
@@ -974,16 +974,13 @@
 <string name="production">Produção</string>
 <string name="training">Treinamento</string>
 <string name="custom">Personalizado</string>
-
-
-    <string name="splash_progress_init_db">Inicializando banco de dados …</string>
-    <string name="splash_progress_downloading_languages">Baixe os termos do idioma atual …</string>
-    <string name="splash_progress_executing_maintenance_task">Executando tarefa de manutenção …</string>
-
-    <string name="pull_dialog_progress_generic_message">Atualizando Metadados …</string>
-    <string name="push_invalid_credentials">detectamos que o pino foi alterado no servidor, insira o pino novamente</string>
-
-
-    <string name="web_view_network_error">Há problemas de rede ao carregar a página da web</string>
-    <string name="push_network_error">Há problemas de rede no processo de envio</string>
+<string name="splash_progress_init_db">Inicializando banco de dados …</string>
+<string name="splash_progress_downloading_languages">Baixe os termos do idioma atual …</string>
+<string name="splash_progress_executing_maintenance_task">Executando tarefa de manutenção …</string>
+<string name="pull_dialog_progress_generic_message">Atualizando Metadados …</string>
+<string name="push_invalid_credentials">detectamos que o pino foi alterado no servidor, insira o pino novamente</string>
+<string name="web_view_network_error">Há problemas de rede ao carregar a página da web</string>
+<string name="push_network_error">Há problemas de rede no processo de envio</string>
+<string name="preference_jumping_survey_views_title">Saltando no Inquérito</string>
+<string name="preference_jumping_survey_views_summary">Ative pulando entre as vistas na pesquisa</string>
 </resources>

--- a/app/src/ereferrals/res/values-sw/strings.xml
+++ b/app/src/ereferrals/res/values-sw/strings.xml
@@ -1032,14 +1032,13 @@ Ameahidi kuhudhuria"</string>
 <string name="production">Uzalishaji</string>
 <string name="training">Mafunzo</string>
 <string name="custom">Desturi</string>
-
-    <string name="splash_progress_init_db">Initializing database …</string>
-    <string name="splash_progress_downloading_languages">Download current language terms …</string>
-    <string name="splash_progress_executing_maintenance_task">Executing maintenance task …</string>
-
-    <string name="pull_dialog_progress_generic_message">Inasasisha metadata …</string>
-    <string name="push_invalid_credentials">tumegundua kuwa siri imebadilika kwenye seva, tafadhali ingiza tena siri</string>
-
-    <string name="web_view_network_error">Kuna matatizo ya mtandao kupakia mtandao wa pag</string>
-    <string name="push_network_error">Kuna matatizo ya mtandao kwenye mchakato wa kushinikiza</string>
+<string name="splash_progress_init_db">Initializing database …</string>
+<string name="splash_progress_downloading_languages">Download current language terms …</string>
+<string name="splash_progress_executing_maintenance_task">Executing maintenance task …</string>
+<string name="pull_dialog_progress_generic_message">Inasasisha metadata …</string>
+<string name="push_invalid_credentials">tumegundua kuwa siri imebadilika kwenye seva, tafadhali ingiza tena siri</string>
+<string name="web_view_network_error">Kuna matatizo ya mtandao kupakia mtandao wa pag</string>
+<string name="push_network_error">Kuna matatizo ya mtandao kwenye mchakato wa kushinikiza</string>
+<string name="preference_jumping_survey_views_title">Kuruka katika Utafiti</string>
+<string name="preference_jumping_survey_views_summary">Wezesha kuruka kati ya maoni katika utafiti</string>
 </resources>

--- a/app/src/ereferrals/res/values/donottranslate.xml
+++ b/app/src/ereferrals/res/values/donottranslate.xml
@@ -78,6 +78,7 @@
     <string name="program_configuration_endpoint" translatable="false">"program_configuration_endpoint"</string>
     <string name="program_configuration_user" translatable="false">"program_configuration_user"</string>
     <string name="program_configuration_pass" translatable="false">"program_configuration_pass"</string>
+    <string name="preference_jumping_survey_views_key" translatable="false">"preference_jumping_survey_views_key"</string>
     <string-array name="server_list">
         <item>@string/production</item>
         <item>@string/training</item>

--- a/app/src/ereferrals/res/values/strings.xml
+++ b/app/src/ereferrals/res/values/strings.xml
@@ -1140,18 +1140,13 @@
 <string name="production">Production</string>
 <string name="training">Training</string>
 <string name="custom">Custom</string>
-
-
-    <string name="splash_progress_init_db">Initializing database …</string>
-    <string name="splash_progress_downloading_languages">Download current language terms …</string>
-    <string name="splash_progress_executing_maintenance_task">Executing maintenance task …</string>
-
-
-
-    <string name="pull_dialog_progress_generic_message">Updating metadata …</string>
-    <string name="push_invalid_credentials">we have detected that the pin has changed on the server, please insert the pin again</string>
-
-
-    <string name="web_view_network_error">There were network problems while loading the web page</string>
-    <string name="push_network_error">There were network problems while sending vouchers to the server</string>
+<string name="splash_progress_init_db">Initializing database …</string>
+<string name="splash_progress_downloading_languages">Download current language terms …</string>
+<string name="splash_progress_executing_maintenance_task">Executing maintenance task …</string>
+<string name="pull_dialog_progress_generic_message">Updating metadata …</string>
+<string name="push_invalid_credentials">we have detected that the pin has changed on the server, please insert the pin again</string>
+<string name="web_view_network_error">There were network problems while loading the web page</string>
+<string name="push_network_error">There were network problems while sending vouchers to the server</string>
+<string name="preference_jumping_survey_views_title">Jumping in Survey</string>
+<string name="preference_jumping_survey_views_summary">Activate jumping between the views in the survey</string>
 </resources>

--- a/app/src/ereferrals/res/values/strings.xml
+++ b/app/src/ereferrals/res/values/strings.xml
@@ -1147,6 +1147,6 @@
 <string name="push_invalid_credentials">we have detected that the pin has changed on the server, please insert the pin again</string>
 <string name="web_view_network_error">There were network problems while loading the web page</string>
 <string name="push_network_error">There were network problems while sending vouchers to the server</string>
-<string name="preference_jumping_survey_views_title">Jumping in Survey</string>
-<string name="preference_jumping_survey_views_summary">Activate jumping between the views in the survey</string>
+<string name="preference_jumping_survey_views_title">Question jumping</string>
+<string name="preference_jumping_survey_views_summary">Activate jumping to the next question when previous one is finished</string>
 </resources>

--- a/app/src/ereferrals/res/xml/pref_general.xml
+++ b/app/src/ereferrals/res/xml/pref_general.xml
@@ -159,6 +159,11 @@
             android:key="@string/activate_elements_key"
             android:summary="@string/activate_elements"
             android:title="@string/elements" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="@string/preference_jumping_survey_views_key"
+            android:summary="@string/preference_jumping_survey_views_summary"
+            android:title="@string/preference_jumping_survey_views_title" />
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/SurveyFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/SurveyFragment.java
@@ -36,6 +36,8 @@ import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 import org.eyeseetea.malariacare.data.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.data.database.utils.Session;
 import org.eyeseetea.malariacare.domain.exception.LoadingSurveyException;
+import org.eyeseetea.malariacare.domain.usecase.GetSettingsUseCase;
+import org.eyeseetea.malariacare.factories.SettingsFactory;
 import org.eyeseetea.malariacare.layout.adapters.survey.DynamicTabAdapter;
 import org.eyeseetea.malariacare.layout.adapters.survey.navigation.NavigationBuilder;
 import org.eyeseetea.malariacare.strategies.ASurveyFragmentStrategy;
@@ -148,9 +150,9 @@ public class SurveyFragment extends Fragment {
         DashboardActivity.dashboardActivity.beforeExit();
     }
 
-    public static void  closeKeyboard(){
+    public static void closeKeyboard() {
         Log.d(TAG, "close keyboard");
-        if(listView!=null) {
+        if (listView != null) {
             CommonQuestionView.hideKeyboard(listView.getContext(), listView);
         }
     }
@@ -222,29 +224,44 @@ public class SurveyFragment extends Fragment {
 
     private void showSurvey() {
         try {
-            SurveyFragmentStrategy.isSurveyCreatedFromOtherApp(new ASurveyFragmentStrategy.Callback() {
 
-                @Override
-                public void loadIsSurveyCreatedInOtherApp(boolean isSurveyCreatedInOtherApp) {
-                    LayoutInflater inflater = LayoutInflater.from(getActivity().getApplicationContext());
+            SurveyFragmentStrategy.isSurveyCreatedFromOtherApp(
+                    new ASurveyFragmentStrategy.Callback() {
 
-                    dynamicTabAdapter = new DynamicTabAdapter(getActivity(), mReviewMode, isSurveyCreatedInOtherApp);
+                        @Override
+                        public void loadIsSurveyCreatedInOtherApp(
+                                final boolean isSurveyCreatedInOtherApp) {
 
-                    View viewContent = inflater.inflate(dynamicTabAdapter.getLayout(), content, false);
+                            SurveyFragmentStrategy.isSurveyJumpingActive(
+                                    new ASurveyFragmentStrategy.GetSurveyJumpingCallback() {
+                                        @Override
+                                        public void onSuccess(boolean jumpingActive) {
+                                            LayoutInflater inflater = LayoutInflater.from(
+                                                    getActivity().getApplicationContext());
 
-                    content.removeAllViews();
-                    content.addView(viewContent);
+                                            dynamicTabAdapter = new DynamicTabAdapter(getActivity(), mReviewMode,
+                                                    isSurveyCreatedInOtherApp, jumpingActive);
 
-            listView = (ListView) llLayout.findViewById(R.id.listView);
+                                            View viewContent = inflater.inflate(dynamicTabAdapter.getLayout(),
+                                                    content, false);
 
-            dynamicTabAdapter.addOnSwipeListener(listView);
+                                            content.removeAllViews();
+                                            content.addView(viewContent);
 
-            listView.setAdapter(dynamicTabAdapter);
+                                            listView = (ListView) llLayout.findViewById(R.id.listView);
 
-                    hideProgress();
-                }
-            }, getActivity().getApplicationContext());
-        }catch (NullPointerException e){
+                                            dynamicTabAdapter.addOnSwipeListener(listView);
+
+                                            listView.setAdapter(dynamicTabAdapter);
+
+                                            hideProgress();
+                                        }
+                                    }, getActivity().getApplicationContext());
+
+
+                        }
+                    }, getActivity().getApplicationContext());
+        } catch (NullPointerException e) {
             new LoadingSurveyException(e);
         }
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/DynamicTabAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/DynamicTabAdapter.java
@@ -114,7 +114,7 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
     public static int failedValidations;
 
     public static View navigationButtonHolder;
-    private final Context context;
+    public final Context context;
     public NavigationController navigationController;
     public boolean reloadingQuestionFromInvalidOption;
     TabDB mTabDB;
@@ -143,7 +143,9 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
     private boolean isBackward = true;
     private boolean isASurveyCreatedInOtherApp;
 
-    public DynamicTabAdapter(Context context, boolean reviewMode, boolean isASurveyCreatedInOtherApp) throws NullPointerException {
+    public DynamicTabAdapter(Context context, boolean reviewMode,
+            boolean isASurveyCreatedInOtherApp, boolean jumpingActive) throws NullPointerException {
+
         this.isASurveyCreatedInOtherApp = isASurveyCreatedInOtherApp;
         mReviewMode = reviewMode;
         this.lInflater = LayoutInflater.from(context);
@@ -175,7 +177,7 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
         navigationController.setTotalPages(totalPages);
         isClicked = false;
 
-        mDynamicTabAdapterStrategy = new DynamicTabAdapterStrategy(this);
+        mDynamicTabAdapterStrategy = new DynamicTabAdapterStrategy(this, jumpingActive);
         mDynamicTabAdapterStrategy.initSurveys(readOnly);
     }
 
@@ -603,6 +605,9 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
                 mMultiQuestionViews.add((IMultiQuestionView) questionView);
                 ((IMultiQuestionView) questionView).setHeader(
                         translate(screenQuestionDB.getForm_name()));
+
+                mDynamicTabAdapterStrategy.setJumpingNextQuestionActive(
+                        (CommonQuestionView)questionView);
             }
 
             addTagQuestion(screenQuestionDB, (View) questionView);

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/strategies/ADynamicTabAdapterStrategy.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/strategies/ADynamicTabAdapterStrategy.java
@@ -114,4 +114,8 @@ public abstract class ADynamicTabAdapterStrategy {
 
     public void showValidationErrors() {
     }
+
+    public void setJumpingNextQuestionActive(CommonQuestionView questionView) {
+        questionView.setJumpingNextQuestionActive(false);
+    }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/strategies/ASurveyFragmentStrategy.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/strategies/ASurveyFragmentStrategy.java
@@ -1,5 +1,7 @@
 package org.eyeseetea.malariacare.strategies;
 
+import android.content.Context;
+
 import org.eyeseetea.malariacare.data.database.model.QuestionDB;
 import org.eyeseetea.malariacare.data.database.model.SurveyDB;
 
@@ -7,6 +9,10 @@ public abstract class ASurveyFragmentStrategy {
 
     public interface Callback {
         void loadIsSurveyCreatedInOtherApp(boolean value);
+    }
+
+    public interface GetSurveyJumpingCallback{
+        void onSuccess(boolean value);
     }
 
     abstract SurveyDB getRenderSurvey(QuestionDB screenQuestionDB);
@@ -18,4 +24,10 @@ public abstract class ASurveyFragmentStrategy {
     abstract boolean isStockSurvey(SurveyDB surveyDB);
 
     abstract String getMalariaProgram();
+
+    public void isSurveyJumpingActive (
+            GetSurveyJumpingCallback callback,
+            Context context){
+        callback.onSuccess(false);
+    }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/AKeyboardQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/AKeyboardQuestionView.java
@@ -19,6 +19,17 @@ public abstract class AKeyboardQuestionView extends CommonQuestionView implement
         super(context);
     }
 
+    @Override
+    public void setJumpingNextQuestionActive(boolean jumpingNextQuestionActive) {
+        super.setJumpingNextQuestionActive(jumpingNextQuestionActive);
+
+        if (jumpingNextQuestionActive){
+            answer.setImeOptions(EditorInfo.IME_ACTION_NEXT);
+        } else {
+            answer.setImeOptions(EditorInfo.IME_ACTION_DONE);
+        }
+    }
+
     public void setOnAnswerChangedListener(onAnswerChangedListener onAnswerChangedListener) {
         mOnAnswerChangedListener = onAnswerChangedListener;
         initEditTextActionListener();

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/AKeyboardQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/AKeyboardQuestionView.java
@@ -47,12 +47,6 @@ public abstract class AKeyboardQuestionView extends CommonQuestionView implement
         editText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
             @Override
             public boolean onEditorAction(TextView textView, int actionId, KeyEvent event) {
-
-                IQuestionView nextQuestionView = getNextQuestionView();
-                if (nextQuestionView == null || nextQuestionView instanceof AKeyboardQuestionView
-                        || !(nextQuestionView instanceof IMultiQuestionView)) {
-                    return false;
-                }
                 if (actionId == EditorInfo.IME_ACTION_NEXT
                         || actionId == EditorInfo.IME_ACTION_DONE) {
                     CommonQuestionView.hideKeyboard(textView.getContext(), textView);

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/AKeyboardQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/AKeyboardQuestionView.java
@@ -58,6 +58,11 @@ public abstract class AKeyboardQuestionView extends CommonQuestionView implement
         editText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
             @Override
             public boolean onEditorAction(TextView textView, int actionId, KeyEvent event) {
+                IQuestionView nextQuestionView = getNextQuestionView();
+                 if (nextQuestionView == null || nextQuestionView instanceof AKeyboardQuestionView
+                         || !(nextQuestionView instanceof IMultiQuestionView)) {
+                     return false;
+                 }
                 if (actionId == EditorInfo.IME_ACTION_NEXT
                         || actionId == EditorInfo.IME_ACTION_DONE) {
                     CommonQuestionView.hideKeyboard(textView.getContext(), textView);

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/CommonQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/CommonQuestionView.java
@@ -21,11 +21,21 @@ public class CommonQuestionView extends LinearLayout {
 
     private TableRow mTableRow;
     private ViewGroup mLayout;
+    private boolean jumpingNextQuestionActive;
 
     public Question question;
 
+
     public CommonQuestionView(Context context) {
         super(context);
+    }
+
+    public boolean isJumpingNextQuestionActive() {
+        return jumpingNextQuestionActive;
+    }
+
+    public void setJumpingNextQuestionActive(boolean jumpingNextQuestionActive) {
+        this.jumpingNextQuestionActive = jumpingNextQuestionActive;
     }
 
     public boolean isActive() {
@@ -93,26 +103,28 @@ public class CommonQuestionView extends LinearLayout {
     }
 
     public void focusNextQuestion() {
-        View nextView = getNextView();
-        if (nextView == null) {
-            return;
-        }
+        if (jumpingNextQuestionActive){
+            View nextView = getNextView();
+            if (nextView == null) {
+                return;
+            }
 
-        while (nextView.getVisibility() == View.GONE &&
-                mLayout.indexOfChild(nextView) + 1 < mLayout.getChildCount()) {
-            nextView = mLayout.getChildAt(
-                    mLayout.indexOfChild(nextView) + 1);
-        }
-        if (nextView.getVisibility() != View.GONE) {
-            IQuestionView nextQuestionView =
-                    (IQuestionView) ((TableRow) nextView).getChildAt(
-                            0);
+            while (nextView.getVisibility() == View.GONE &&
+                    mLayout.indexOfChild(nextView) + 1 < mLayout.getChildCount()) {
+                nextView = mLayout.getChildAt(
+                        mLayout.indexOfChild(nextView) + 1);
+            }
+            if (nextView.getVisibility() != View.GONE) {
+                IQuestionView nextQuestionView =
+                        (IQuestionView) ((TableRow) nextView).getChildAt(
+                                0);
 
-            if (thisAndNextQuestionAreAKeyboardQuestionView(nextQuestionView)) {
-                // use standard Android requestFocus only between keyboard questions
-                nextView.requestFocus();
-            } else {
-                ((IMultiQuestionView) nextQuestionView).requestAnswerFocus();
+                if (thisAndNextQuestionAreAKeyboardQuestionView(nextQuestionView)) {
+                    // use standard Android requestFocus only between keyboard questions
+                    nextView.requestFocus();
+                } else {
+                    ((IMultiQuestionView) nextQuestionView).requestAnswerFocus();
+                }
             }
         }
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/DropdownMultiQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/DropdownMultiQuestionView.java
@@ -123,6 +123,7 @@ public class DropdownMultiQuestionView extends AOptionQuestionView implements IQ
     @Override
     public void requestAnswerFocus() {
         spinnerOptions.requestFocusFromTouch();
+        spinnerOptions.performClick();
     }
 
     @Override

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/DropdownWithFilterMultiQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/DropdownWithFilterMultiQuestionView.java
@@ -56,6 +56,7 @@ public class DropdownWithFilterMultiQuestionView extends AOptionQuestionView imp
 
     @Override
     public void requestAnswerFocus() {
+        showDialog(getContext());
     }
 
     @Override
@@ -93,6 +94,7 @@ public class DropdownWithFilterMultiQuestionView extends AOptionQuestionView imp
         inflate(context, R.layout.multi_question_tab_spinner_with_filter_row, this);
         header = (CustomTextView) findViewById(R.id.row_header_text);
         spinnerAsButton = (Spinner) findViewById(R.id.answer);
+
         if(isEnabled()){
             spinnerAsButton.setOnTouchListener(new OnTouchListener(context));
         }

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/LabelMultiQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/LabelMultiQuestionView.java
@@ -60,7 +60,7 @@ public class LabelMultiQuestionView extends CommonQuestionView implements IQuest
 
     @Override
     public void requestAnswerFocus() {
-        helpTextView.requestFocus();
+        focusNextQuestion();
     }
 
     private void init(Context context) {

--- a/app/src/testEreferrals/java/org/eyeseetea/malariacare/domain/entity/SettingsTest.java
+++ b/app/src/testEreferrals/java/org/eyeseetea/malariacare/domain/entity/SettingsTest.java
@@ -22,7 +22,7 @@ public class SettingsTest {
         String currentLanguage = null;
 
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
 
         assertThat(settings.getUser(), is(programUser));
     }
@@ -33,7 +33,7 @@ public class SettingsTest {
         String currentLanguage = null;
 
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
 
         assertThat(settings.getPass(), is(programPass));
     }
@@ -44,7 +44,7 @@ public class SettingsTest {
         String currentLanguage = null;
 
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
 
         assertThat(settings.getWsServerUrl(), is(programUrl));
     }
@@ -55,7 +55,7 @@ public class SettingsTest {
         String currentLanguage = null;
 
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
 
         assertThat(settings.getLanguage(), is(systemLanguage));
     }
@@ -66,7 +66,7 @@ public class SettingsTest {
         String currentLanguage = "";
 
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
 
         assertThat(settings.getLanguage(), is(systemLanguage));
     }
@@ -77,7 +77,7 @@ public class SettingsTest {
         String currentLanguage = "sw";
 
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
 
         assertThat(settings.getLanguage(), is(currentLanguage));
     }
@@ -90,7 +90,7 @@ public class SettingsTest {
         thrown.expect(IllegalArgumentException.class);
 
         new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
     }
 
     @Test
@@ -101,7 +101,7 @@ public class SettingsTest {
         thrown.expect(IllegalArgumentException.class);
 
         new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
     }
 
     @Test
@@ -112,7 +112,7 @@ public class SettingsTest {
         thrown.expect(IllegalArgumentException.class);
 
         new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
     }
 
     @Test
@@ -123,7 +123,7 @@ public class SettingsTest {
         thrown.expect(IllegalArgumentException.class);
 
         new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
     }
 
     @Test
@@ -134,7 +134,7 @@ public class SettingsTest {
         thrown.expect(IllegalArgumentException.class);
 
         new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
     }
 
     @Test
@@ -144,7 +144,7 @@ public class SettingsTest {
         boolean canDownloadWith3G = true;
 
         Settings settings = new Settings(systemLanguage, currentLanguage, null, true, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
 
         assertThat(settings.canDownloadWith3G(), is(canDownloadWith3G));
     }
@@ -156,7 +156,7 @@ public class SettingsTest {
         boolean canDownloadWith3G = false;
 
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
 
         assertThat(settings.canDownloadWith3G(), is(canDownloadWith3G));
     }
@@ -168,7 +168,7 @@ public class SettingsTest {
         boolean isElementActive = true;
 
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, true, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
 
         assertThat(settings.isElementActive(), is(isElementActive));
     }
@@ -180,7 +180,7 @@ public class SettingsTest {
         boolean isElementActive = false;
 
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
 
         assertThat(settings.isElementActive(), is(isElementActive));
     }
@@ -193,7 +193,7 @@ public class SettingsTest {
         boolean isMetadataUpdateActive = false;
 
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
 
         assertThat(settings.isMetadataUpdateActive(), is(isMetadataUpdateActive));
     }
@@ -206,7 +206,7 @@ public class SettingsTest {
         boolean isMetadataUpdateActive = true;
 
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, false, true,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
 
         assertThat(settings.isMetadataUpdateActive(), is(isMetadataUpdateActive));
     }
@@ -216,7 +216,7 @@ public class SettingsTest {
         String systemLanguage = "en";
         String currentLanguage = "en";
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
 
         assertThat(settings.getMediaListMode(), is(ISettingsRepository.MediaListMode.GRID));
     }
@@ -227,7 +227,7 @@ public class SettingsTest {
         String currentLanguage = "en";
         Settings settings = new Settings(systemLanguage, currentLanguage,
                 ISettingsRepository.MediaListMode.LIST, false, false, false,
-                programUser, programPass, programUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, null, null, false, false, "1",true);
 
         assertThat(settings.getMediaListMode(), is(ISettingsRepository.MediaListMode.LIST));
     }
@@ -238,7 +238,7 @@ public class SettingsTest {
         String currentLanguage = "en";
         String webServiceUrl = "webServiceUrl";
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, webServiceUrl, null, null, null, null, false, false, "1");
+                programUser, programPass, webServiceUrl, null, null, null, null, false, false, "1",true);
         assertThat(settings.getWsServerUrl(), is(webServiceUrl));
     }
 
@@ -248,7 +248,7 @@ public class SettingsTest {
         String currentLanguage = "en";
         String webUrl = "webUrl";
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, webUrl, null, null, null, false, false, "1");
+                programUser, programPass, programUrl, webUrl, null, null, null, false, false, "1",true);
         assertThat(settings.getWebUrl(), is(webUrl));
     }
 
@@ -258,7 +258,7 @@ public class SettingsTest {
         String currentLanguage = "en";
         String fontSize = "fontSize";
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, fontSize, null, null, false, false, "1");
+                programUser, programPass, programUrl, null, fontSize, null, null, false, false, "1",true);
         assertThat(settings.getFontSize(), is(fontSize));
     }
 
@@ -268,7 +268,7 @@ public class SettingsTest {
         String currentLanguage = "en";
         String programUrl = "programUrl";
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, false, false,
-                programUser, programPass, programUrl, null, null, programUrl, null, false, false, "1");
+                programUser, programPass, programUrl, null, null, programUrl, null, false, false, "1",true);
         assertThat(settings.getProgramUrl(), is(programUrl));
     }
     @Test
@@ -278,7 +278,7 @@ public class SettingsTest {
         String programEndpoint = "programEndpoint";
         Settings settings = new Settings(systemLanguage, currentLanguage, null, false, false, false,
                 programUser, programPass, programUrl, null, null, null, programEndpoint, false,
-                false, "1");
+                false, "1",true);
         assertThat(settings.getProgramEndPoint(), is(programEndpoint));
     }
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2420  
* **Related pull-requests:** 

### :tophat: What is the goal?

 - Make jumping between questions consistent (for dropdowns and autocomplete open the selection as for date pickers.
  - Add setting to disable jumping

###   :gear: branches 
**app**:
       Origin: maintenance/change_keyboard_in_soft_login_to_numeric Target: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

 - I have fixed a bug to jump to dropdowns
- I have added a new preference to activate/deactivate jumping and I have configured the jumping in views according to the preference

### :boom: How can it be tested?

**Use Case 1**:  Enter the app and the jumping should be active by default and jumping behaviour working when to create a new survey.

**Use Case 2**:  Enter the app and disable jumping in settings then the jumping behaviour should not work when to create a new survey.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots

![device-2019-06-11-115704](https://user-images.githubusercontent.com/5593590/59262739-2058d900-8c40-11e9-92f6-99ca3d7d3d09.png)
