### PR TITLE
Avoid saving values when survey is open in review mode:

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/DynamicTabAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/DynamicTabAdapter.java
@@ -306,11 +306,14 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
         }
     }
 
-
     public void saveTextValue(View view, String newValue, boolean moveToNextQuestion) {
         QuestionDB questionDB = (QuestionDB) view.getTag();
-        questionDB.saveValuesText(newValue, isASurveyCreatedInOtherApp);
-        executeTabLogic(questionDB, null);
+
+        if (!mReviewMode){
+            questionDB.saveValuesText(newValue, isASurveyCreatedInOtherApp);
+            executeTabLogic(questionDB, null);
+        }
+
         if (moveToNextQuestion) {
             navigationController.isMovingToForward = true;
             finishOrNext();
@@ -318,6 +321,7 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
             showOrHideChildren(questionDB);
         }
     }
+    
 
     public void saveOptionValue(View view, OptionDB selectedOptionDB, QuestionDB questionDB,
             boolean moveToNextQuestion) {
@@ -329,8 +333,9 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
             isBackward = false;
         }
 
-        questionDB.saveValuesDDL(selectedOptionDB, valueDB);
-
+        if (!mReviewMode) {
+            questionDB.saveValuesDDL(selectedOptionDB, valueDB);
+        }
 
         if (questionDB.getOutput().equals(Constants.IMAGE_3_NO_DATAELEMENT) ||
                 questionDB.getOutput().equals(Constants.IMAGE_RADIO_GROUP_NO_DATAELEMENT)) {
@@ -566,6 +571,10 @@ public class DynamicTabAdapter extends BaseAdapter implements ITabAdapter {
         swipeTouchListener.clearClickableViews();
         for (QuestionDB screenQuestionDB : screenQuestionDBs) {
             renderQuestion(rowView, tabType, screenQuestionDB);
+        }
+
+        if (TabDB.isMultiQuestionTab(tabType)){
+            mReviewMode = false;
         }
 
         rowView.requestLayout();


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2418  
* **Related pull-requests:** 

### :tophat: What is the goal?

- The real bug is when you open survey in review mode (opened from review fragment) then some values are lost.

###   :gear: branches 
**app**:
       Origin: maintenance/change_keyboard_in_soft_login_to_numeric Target: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

The lost values are values of child questions because change logic is fired when to assign value in parent . This logic remove child values on save parent process.

I have modified DynamicTabAdapter to avoid saving values when the survey is open in review modeand after loading all values and if is multi-question tab then I deactive review mode

### :boom: How can it be tested?

**Use Case 1**:  Create different combinations of surveys and click on cancel button in review screen to go back to the survey in review mode, any value should not be lost.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots
