### PR TITLE
Manage all IOException during push eReferralsAPIClient as NetworkExce…

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/exporter/eReferralsAPIClient.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/exporter/eReferralsAPIClient.java
@@ -115,15 +115,14 @@ public class eReferralsAPIClient {
         } catch (UnrecognizedPropertyException e) {
             ConversionException conversionException = new ConversionException(e);
             wsClientCallBack.onError(conversionException);
-        } catch (SocketTimeoutException | UnknownHostException e) {
+        } catch (IOException e) {
             wsClientCallBack.onError(new NetworkException());
             return;
         } catch (AvailableApiException e) {
             wsClientCallBack.onError(e);
             return;
-        } catch (IOException e) {
-            wsClientCallBack.onError(e);
         }
+
         if (response != null && response.code() == 401) {
             ConversionException conversionException = new ConversionException(null);
             wsClientCallBack.onError(conversionException);


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2417   
* **Related pull-requests:** 

### :tophat: What is the goal?

I interrupted the synchronisation of a record voluntarily.
The record turned "red" when I would expect it to turn "orange" and attempt synchronisation again at a later stage.
Note that in some cases (most?) it turns "orange" as expected, but it sometimes does not and the user cannot know whether the record has been properly synchronised or not.

###   :gear: branches 
**app**:
       Origin: maintenance/change_keyboard_in_soft_login_to_numeric Target: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

The problem is that only SocketTimeoutException and UnknownHostException derivated class from IOException was treated as NetworkException. I have modified the cath to superclass IOException.

Now all IOExceptions are treated as NetworkException in eReferralsAPIClient and when push controller receives a NetworkException then survey status is assigned to Quarantine.

### :boom: How can it be tested?

**Use Case 1**:  Create a new survey and during push process change plane mode to on, the survey should appear in brown color (Quarantine) and send it in the next push.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots
