### PR TITLE
For the second important name get index 1

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/layout/adapters/survey/SurveysAdapter.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/layout/adapters/survey/SurveysAdapter.java
@@ -158,7 +158,7 @@ public class SurveysAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
 
                 if (survey.getImportantValues().size() > 1) {
                     secondImportant =
-                            Utils.getInternationalizedString(survey.getImportantValues().get(0));
+                            Utils.getInternationalizedString(survey.getImportantValues().get(1));
                 }
             }
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2427   
* **Related pull-requests:** 

### :tophat: What is the goal?

The dashboard seems to display as IMPORTANT the first field of the form marked as important twice instead of taking into account all fields marked as important.

###   :gear: branches 
**app**:
       Origin: maintenance/solve_to_show_importants_values Target: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

The problem is that always show index 0 of important values. The problem is solved show the index 0 and index 1 if exists

### :boom: How can it be tested?

**Use Case 1**:  Create a new survey and should show two first important values.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots
