### PR TITLE
add staging server

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/LoginActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/LoginActivityStrategy.java
@@ -214,6 +214,11 @@ public class LoginActivityStrategy extends ALoginActivityStrategy {
                             R.string.program_endpoint_training, R.string.web_url_training,
                             R.string.webservice_url_training, false);
                 } else if (value.equals(
+                        parent.getContext().getResources().getString(R.string.staging))) {
+                    setConfiguration(R.string.program_url_staging,
+                            R.string.program_endpoint_staging, R.string.web_url_staging,
+                            R.string.webservice_url_staging, false);
+                } else if (value.equals(
                         parent.getContext().getResources().getString(R.string.custom))) {
                     setConfiguration(R.string.program_url_production,
                             R.string.program_endpoint_production, R.string.web_url_production,

--- a/app/src/ereferrals/res/values-ne/strings.xml
+++ b/app/src/ereferrals/res/values-ne/strings.xml
@@ -977,6 +977,7 @@
 <string name="erro_page_text">"तपाईं अफलाइन हुनुहुन्छ र यो एक अनलाइन मोड्युल हो। यो जानकारी हेर्न कृपया नेटवर्कमा जडान गर्नुहोस्।"</string>
 <string name="production">उत्पादन</string>
 <string name="training">प्रशिक्षण</string>
+<string name="staging">चोटि</string>
 <string name="custom">अनुकूलन</string>
 <string name="splash_progress_init_db">डेटाबेस सुरू गर्दै ...</string>
 <string name="splash_progress_downloading_languages">वर्तमान भाषा सर्तहरू डाउनलोड गर्नुहोस् ...</string>

--- a/app/src/ereferrals/res/values-pt/strings.xml
+++ b/app/src/ereferrals/res/values-pt/strings.xml
@@ -973,6 +973,7 @@
 <string name="erro_page_text">"Você está offline e este é um módulo on-line. Por favor, conecte-se a uma rede para ver esta informação."</string>
 <string name="production">Produção</string>
 <string name="training">Treinamento</string>
+<string name="staging">Encenação</string>
 <string name="custom">Personalizado</string>
 <string name="splash_progress_init_db">Inicializando banco de dados …</string>
 <string name="splash_progress_downloading_languages">Baixe os termos do idioma atual …</string>

--- a/app/src/ereferrals/res/values-sw/strings.xml
+++ b/app/src/ereferrals/res/values-sw/strings.xml
@@ -1031,6 +1031,7 @@ Ameahidi kuhudhuria"</string>
 <string name="erro_page_text">"Uko katika hali ya demo na hii ni moduli ya mtandaoni. Tafadhali ingia na usajili na mtumiaji halali ili kuona habari hii."</string>
 <string name="production">Uzalishaji</string>
 <string name="training">Mafunzo</string>
+<string name="staging">Staging</string>
 <string name="custom">Desturi</string>
 <string name="splash_progress_init_db">Initializing database …</string>
 <string name="splash_progress_downloading_languages">Download current language terms …</string>

--- a/app/src/ereferrals/res/values/donottranslate.xml
+++ b/app/src/ereferrals/res/values/donottranslate.xml
@@ -82,6 +82,7 @@
     <string-array name="server_list">
         <item>@string/production</item>
         <item>@string/training</item>
+        <item>@string/staging</item>
         <item>@string/custom</item>
     </string-array>
     <string name="soft_login_required" translatable="false">"soft_login_required"</string>
@@ -104,9 +105,15 @@
     <string name="program_endpoint_training" translatable="false">dcSettings-train</string>
     <string name="webservice_url_training" translatable="false">https://apps.psi-mis.org/eRefWSTrain/</string>
     <string name="web_url_training" translatable="false">https://apps.psi-mis.org/connect-train/</string>
+
+    <!-- staging urls -->
+    <string name="program_url_staging" translatable="false">https://data.psi-mis.org/api/dataStore/Connect_config/</string>
+    <string name="program_endpoint_staging" translatable="false">dcSettings-stage</string>
+    <string name="webservice_url_staging" translatable="false">https://apps.psi-mis.org/eRefWSStage/</string>
+    <string name="web_url_staging" translatable="false">https://apps.psi-mis.org/connect-stage/</string>
+
+
     <string name="last_push_date" translatable="false">last_push_date</string>
     <string name="ENABLE_MANUAL_PUSH_PERIOD" translatable="false">30</string>
-
-
     <string name="web_view_timeout_millis" translatable="false">15000</string>
 </resources>

--- a/app/src/ereferrals/res/values/strings.xml
+++ b/app/src/ereferrals/res/values/strings.xml
@@ -1139,6 +1139,7 @@
 <string name="erro_page_text">"You're offline and this is an online module. Please connect to a network in order to see this information."</string>
 <string name="production">Production</string>
 <string name="training">Training</string>
+<string name="staging">Staging</string>
 <string name="custom">Custom</string>
 <string name="splash_progress_init_db">Initializing database …</string>
 <string name="splash_progress_downloading_languages">Download current language terms …</string>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2429 
* **Related pull-requests:** 

### :tophat: What is the goal?

Include a new server with all the related URLs

###   :gear: branches 
**app**:
       Origin: maintenance/add-staging-server Target: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

Added to all strings in donottranslate and strings-xx.xml the URLs and translations and finally on LoginActivityStrategy loaded those new variables

### :boom: How can it be tested?

**Use Case 1**:  Execute a full login and select advance settings in login, and the new staging server. Add the interceptor to HTTPClientFactory to see the URLs and jsons sent to the server and check that all URLs are the proper ones

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots