### PR TITLE
Add password variation to password edit text in soft login

### DIFF
--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/views/SoftLoginDialogFragment.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/views/SoftLoginDialogFragment.java
@@ -1,5 +1,8 @@
 package org.eyeseetea.malariacare.views;
 
+import static android.text.InputType.TYPE_CLASS_NUMBER;
+import static android.text.InputType.TYPE_NUMBER_VARIATION_PASSWORD;
+
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -104,7 +107,7 @@ public class SoftLoginDialogFragment extends DialogFragment implements SoftLogin
         userNameEditText.setEnabled(false);
         passwordEditText = view.findViewById(R.id.edittext_password);
 
-        passwordEditText.setInputType(InputType.TYPE_CLASS_NUMBER);
+        passwordEditText.setInputType(TYPE_CLASS_NUMBER | TYPE_NUMBER_VARIATION_PASSWORD);
 
         passwordEditText.addTextChangedListener(new TextWatcher() {
             @Override


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2432   
* **Related pull-requests:** 

### :tophat: What is the goal?

- Use a password text field to enter the PIN so it's hidden while entered

###   :gear: branches 
**app**:
       Origin: maintenance/change_soft_login_password_edit_text_to_number_paswordTarget: v1.4_connect
**bugshaker-android**:
       Origin: downgrade_gradle_version
**EyeSeeTea-sdk**:
       Origin: Development
       
### :memo: How is it being implemented?

Setting input type in password edit text for soft login to TYPE_CLASS_NUMBER | TYPE_NUMBER_VARIATION_PASSWORD)

### :boom: How can it be tested?

**Use Case 1**:  Soft login password should be hidden while writing

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots
