### PR TITLE
Add copy and share voucherUid actions to end survey message

### DIFF
--- a/app/src/ereferrals/res/values-ne/strings.xml
+++ b/app/src/ereferrals/res/values-ne/strings.xml
@@ -988,4 +988,8 @@
 <string name="push_network_error">प्रक्रिया प्रक्रियामा सञ्जाल समस्याहरू छन्</string>
 <string name="preference_jumping_survey_views_title">सर्वेक्षणमा जम्पिङ</string>
 <string name="preference_jumping_survey_views_summary">सर्वेक्षणमा हेराइहरू बीचमा जम्पिङ सक्रिय गर्नुहोस्</string>
+
+<string name="action_ok">ठीक छ</string>
+<string name="action_copy">प्रतिलिपि</string>
+<string name="action_share">सेयर</string>
 </resources>

--- a/app/src/ereferrals/res/values-pt/strings.xml
+++ b/app/src/ereferrals/res/values-pt/strings.xml
@@ -984,4 +984,8 @@
 <string name="push_network_error">Há problemas de rede no processo de envio</string>
 <string name="preference_jumping_survey_views_title">Saltando no Inquérito</string>
 <string name="preference_jumping_survey_views_summary">Ative pulando entre as vistas na pesquisa</string>
+
+<string name="action_ok">ok</string>
+<string name="action_copy">copiar</string>
+<string name="action_share">partilhar</string>
 </resources>

--- a/app/src/ereferrals/res/values-sw/strings.xml
+++ b/app/src/ereferrals/res/values-sw/strings.xml
@@ -1042,4 +1042,8 @@ Ameahidi kuhudhuria"</string>
 <string name="push_network_error">Kuna matatizo ya mtandao kwenye mchakato wa kushinikiza</string>
 <string name="preference_jumping_survey_views_title">Kuruka katika Utafiti</string>
 <string name="preference_jumping_survey_views_summary">Wezesha kuruka kati ya maoni katika utafiti</string>
+
+<string name="action_ok">sawa</string>
+<string name="action_copy">nakala</string>
+<string name="action_share">kushiriki</string>
 </resources>

--- a/app/src/ereferrals/res/values/strings.xml
+++ b/app/src/ereferrals/res/values/strings.xml
@@ -1150,4 +1150,9 @@
 <string name="push_network_error">There were network problems while sending vouchers to the server</string>
 <string name="preference_jumping_survey_views_title">Question jumping</string>
 <string name="preference_jumping_survey_views_summary">Activate jumping to the next question when previous one is finished</string>
+
+<string name="action_ok">OK</string>
+<string name="action_copy">COPY</string>
+<string name="action_share">SHARE</string>
+
 </resources>

--- a/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
@@ -124,7 +124,7 @@ public class DashboardActivity extends BaseActivity {
                 .setCancelable(false)
                 .setTitle(dialogTitle)
                 .setMessage(dialogMessage)
-                .setNeutralButton(android.R.string.ok, listener)
+                .setNeutralButton(R.string.action_ok, listener)
                 .create().show();
     }
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2439                
* **Related pull-requests:** 

###   :gear: branches 
**app**: 
       Origin: feature/Add_copy_and_share_voucheruid_actions Target: v1.4_connect
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   

### :tophat: What is the goal?

Add copy and share voucherUid actions to end survey message

### :memo: How is it being implemented?

After review material design guidelines here: https://material.io/components/dialogs/
I have decided to add text buttons instead of icon buttons.

I have created a custom method to show the message with new actions

### :boom: How can it be tested?

**UseCase 1**: create a new survey with voucher uid and on the message should appear copy and share actions working.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-

![voucher_actions](https://user-images.githubusercontent.com/5593590/63830149-b4972a00-c96b-11e9-9b93-404e5ed73fdc.png)
