### PR TITLE
Maintenance/voucher code suffix

### DIFF
--- a/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/services/PushServiceShould.java
+++ b/app/src/androidTestEreferrals/java/org/eyeseetea/malariacare/services/PushServiceShould.java
@@ -109,7 +109,7 @@ public class PushServiceShould {
         LocalBroadcastManager.getInstance(
                 PreferencesState.getInstance().getContext()).registerReceiver(pushReceiver,
                 new IntentFilter(PushService.class.getName()));
-        mPushServiceStrategy = new PushServiceStrategy(new PushService("TestPushService"));
+        mPushServiceStrategy = new PushServiceStrategy(new PushService());
     }
 
     public void grantPhonePermission() {

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationApiClient.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/MetadataConfigurationApiClient.java
@@ -88,7 +88,8 @@ public class MetadataConfigurationApiClient implements IMetadataConfigurationDat
     private String baseUrl;
     private String countryExtension;
 
-    public MetadataConfigurationApiClient(String url, String endpoint, BasicAuthInterceptor basicAuthInterceptor) {
+    public MetadataConfigurationApiClient(String url, String endpoint,
+            BasicAuthInterceptor basicAuthInterceptor) {
 
         baseUrl = url;
         countryExtension = endpoint;
@@ -164,7 +165,8 @@ public class MetadataConfigurationApiClient implements IMetadataConfigurationDat
 
         List<Configuration.CountryVersion> domainCountriesVersions = new ArrayList<>();
 
-        for (CountriesMetadataVersionsApi.CountriesMetadataVersion countriesMetadataVersion : countriesVersionsApi) {
+        for (CountriesMetadataVersionsApi.CountriesMetadataVersion countriesMetadataVersion :
+                countriesVersionsApi) {
 
             Configuration.CountryVersion domain =
                     Configuration.CountryVersion.newBuilder()
@@ -289,7 +291,7 @@ public class MetadataConfigurationApiClient implements IMetadataConfigurationDat
 
     @Nullable
     private CountryMetadataApi.Option findOptionBy(@NonNull String optionCode,
-                                                   @NonNull CountryMetadataApi.Question question) {
+            @NonNull CountryMetadataApi.Question question) {
 
         CountryMetadataApi.Option foundOption = null;
         if (question.options != null) {
@@ -332,7 +334,9 @@ public class MetadataConfigurationApiClient implements IMetadataConfigurationDat
         if (response.isSuccessful()) {
             return response.body();
         } else {
-            String error = response.errorBody().string() + "Http Code: " + response.code() + " url: " + response.raw().request().url();
+            String error =
+                    response.errorBody().string() + "Http Code: " + response.code() + " url: "
+                            + response.raw().request().url();
 
             throw new ApiCallException(error);
         }
@@ -364,7 +368,7 @@ public class MetadataConfigurationApiClient implements IMetadataConfigurationDat
                 domainQuestions.add(domainQuestion);
                 mapDomainQuestionsByCode.put(domainQuestion.getCode(), domainQuestion);
 
-                if(!isImportantQuestionSelected) {
+                if (!isImportantQuestionSelected) {
                     isImportantQuestionSelected = isImportantQuestion(domainQuestion);
                 }
             }
@@ -379,8 +383,8 @@ public class MetadataConfigurationApiClient implements IMetadataConfigurationDat
         private void setImportantDomainQuestion(List<Question> domainQuestions,
                 boolean isImportantQuestionSelected) {
 
-            if(!isImportantQuestionSelected && domainQuestions.size() >=1){
-                Question domainQuestion  = domainQuestions.get(0);
+            if (!isImportantQuestionSelected && domainQuestions.size() >= 1) {
+                Question domainQuestion = domainQuestions.get(0);
                 domainQuestion.setVisibility(IMPORTANT);
             }
         }
@@ -578,6 +582,8 @@ public class MetadataConfigurationApiClient implements IMetadataConfigurationDat
                     .regExp(apiQuestion.validationRegex)
                     .regExpError(apiQuestion.validationPoTerm)
                     .defaultValue(apiQuestion.defaultValue)
+                    .voucherCodeSuffix(
+                            convertToDomainVoucherCodeSuffixFrom(apiQuestion.voucherCodeSuffix))
                     .build();
         }
 
@@ -588,19 +594,19 @@ public class MetadataConfigurationApiClient implements IMetadataConfigurationDat
 
             Question.Visibility domainVisibility;
 
-            switch (apiQuestion.queueDisplayPriority){
+            switch (apiQuestion.queueDisplayPriority) {
 
-                case DISPLAY_PRIORITY_VISIBLE:{
+                case DISPLAY_PRIORITY_VISIBLE: {
                     domainVisibility = VISIBLE;
                     break;
                 }
 
-                case DISPLAY_PRIORITY_INVISIBLE:{
+                case DISPLAY_PRIORITY_INVISIBLE: {
                     domainVisibility = INVISIBLE;
                     break;
                 }
 
-                case DISPLAY_PRIORITY_IMPORTANT:{
+                case DISPLAY_PRIORITY_IMPORTANT: {
                     domainVisibility = IMPORTANT;
                     break;
                 }
@@ -609,6 +615,18 @@ public class MetadataConfigurationApiClient implements IMetadataConfigurationDat
             }
 
             return domainVisibility;
+        }
+
+        @Nullable
+        private Question.VoucherCodeSuffix convertToDomainVoucherCodeSuffixFrom(
+                CountryMetadataApi.VoucherCodeSuffix voucherCodeSuffix) {
+
+            if (voucherCodeSuffix != null) {
+                return new Question.VoucherCodeSuffix(voucherCodeSuffix.suffix,
+                        voucherCodeSuffix.valueCondition);
+            }
+
+            return null;
         }
 
         @Nullable
@@ -715,7 +733,7 @@ public class MetadataConfigurationApiClient implements IMetadataConfigurationDat
         }
 
         private void addToPendingRules(@NonNull CountryMetadataApi.Question apiQuestion,
-                                       @NonNull CountryMetadataApi.Option apiOption, @NonNull Option domainOption) {
+                @NonNull CountryMetadataApi.Option apiOption, @NonNull Option domainOption) {
 
             addItemToListOf(mapDomainOptionsWithRuleByQuestionCodes, apiQuestion.code,
                     domainOption);

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/model/CountryMetadataApi.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/data/sync/importer/metadata/configuration/model/CountryMetadataApi.java
@@ -78,6 +78,14 @@ public class CountryMetadataApi {
 
         public List<Rule> rules;
 
+        public VoucherCodeSuffix voucherCodeSuffix;
+
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class VoucherCodeSuffix {
+        public String suffix;
+        public String valueCondition;
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/service/VoucherSuffixDomainService.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/service/VoucherSuffixDomainService.java
@@ -1,0 +1,56 @@
+package org.eyeseetea.malariacare.domain.service;
+
+import org.eyeseetea.malariacare.domain.entity.Question;
+import org.eyeseetea.malariacare.domain.entity.Survey;
+import org.eyeseetea.malariacare.domain.entity.Value;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class VoucherSuffixDomainService {
+    public String calculate(Survey survey, List<Question> questions){
+        Map<String, Question> questionsMap = new HashMap<>();
+
+        for (Question question : questions) {
+            questionsMap.put(question.getUid(), question);
+        }
+
+        List<String> suffixItems = new ArrayList<>();
+
+        for(Value value: survey.getValues()){
+            Question question = questionsMap.get(value.getQuestionUId());
+
+            if (question!= null && question.getVoucherCodeSuffix() != null &&
+                    question.getVoucherCodeSuffix().suffix != null &&
+                    question.getVoucherCodeSuffix().valueCondition != null){
+
+                if (value.getValue().equals(question.getVoucherCodeSuffix().valueCondition)){
+                    suffixItems.add(question.getVoucherCodeSuffix().suffix);
+                }
+            }
+        }
+
+        return createSuffixFromList("_",suffixItems);
+    }
+
+    private String createSuffixFromList(String separator, List<String> suffixItems) {
+
+        if (suffixItems == null || suffixItems.size() <= 0) return "";
+
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < suffixItems.size(); i++) {
+
+            sb.append(suffixItems.get(i));
+
+            // if not the last item
+            if (i != suffixItems.size() - 1) {
+                sb.append(separator);
+            }
+        }
+
+        return "_" + sb.toString();
+    }
+}

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/usecase/CompletionSurveyUseCase.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/usecase/CompletionSurveyUseCase.java
@@ -54,7 +54,7 @@ public class CompletionSurveyUseCase implements UseCase  {
                 UIDGenerator uidGenerator = new UIDGenerator();
 
                 survey.assignVoucherUid(String.valueOf(uidGenerator.generateUID()));
-                survey.assignVisibleVoucherUid(survey.getOrgUnitUid() + voucherSuffix);
+                survey.assignVisibleVoucherUid(survey.getVoucherUid() + voucherSuffix);
                 survey.changeEventDate(new Date(uidGenerator.getTimeGeneratedUID()));
 
                 surveyRepository.save(survey);

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/usecase/CompletionSurveyUseCase.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/domain/usecase/CompletionSurveyUseCase.java
@@ -1,7 +1,91 @@
 package org.eyeseetea.malariacare.domain.usecase;
 
-public class CompletionSurveyUseCase extends ACompletionSurveyUseCase {
+import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
+import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
+import org.eyeseetea.malariacare.domain.boundary.repositories.IQuestionRepository;
+import org.eyeseetea.malariacare.domain.boundary.repositories.ISurveyRepository;
+import org.eyeseetea.malariacare.domain.entity.Question;
+import org.eyeseetea.malariacare.domain.entity.Survey;
+import org.eyeseetea.malariacare.domain.identifiers.CodeGenerator;
+import org.eyeseetea.malariacare.domain.identifiers.UIDGenerator;
+import org.eyeseetea.malariacare.domain.service.VoucherSuffixDomainService;
+
+import java.util.Date;
+import java.util.List;
+
+public class CompletionSurveyUseCase implements UseCase  {
+
+    private IAsyncExecutor asyncExecutor;
+    private IMainExecutor mainExecutor;
+    private ISurveyRepository surveyRepository;
+    private IQuestionRepository questionRepository;
+    private String surveyUid;
+    CompletionSurveyCallback callback;
+
+    public CompletionSurveyUseCase (
+            IAsyncExecutor asyncExecutor,
+            IMainExecutor mainExecutor,
+            ISurveyRepository surveyRepository,
+            IQuestionRepository questionRepository){
+        this.asyncExecutor = asyncExecutor;
+        this.mainExecutor = mainExecutor;
+        this.surveyRepository = surveyRepository;
+        this.questionRepository = questionRepository;
+    }
+
+    public void execute(String surveyUid, CompletionSurveyCallback callback) {
+        this.surveyUid = surveyUid;
+        this.callback = callback;
+
+        asyncExecutor.run(this);
+    }
+
     @Override
-    public void execute(long idSurvey) {
+    public void run() {
+        Survey survey = surveyRepository.getSurveyByUid(surveyUid);
+
+        if (survey.isCompleted() && survey.getUId() == null) {
+            List<Question> questions =
+                    questionRepository.getQuestionsByProgram(survey.getProgramUid());
+
+            String voucherSuffix = new VoucherSuffixDomainService().calculate(survey, questions);
+
+            UIDGenerator uidGenerator = new UIDGenerator();
+
+            //TODO: Uid should be assigned the first time the survey is created
+            //is created
+            survey.assignUid(CodeGenerator.generateCode());
+
+            survey.assignVoucherUid(String.valueOf(uidGenerator.generateUID()));
+            survey.assignVisibleVoucherUid(survey.getOrgUnitUid() + voucherSuffix);
+            survey.changeEventDate(new Date(uidGenerator.getTimeGeneratedUID()));
+
+            surveyRepository.save(survey);
+
+            notifyCompletionSuccess(survey);
+        }
+    }
+
+    private void  notifyCompletionSuccess(final Survey survey){
+        mainExecutor.run(new Runnable() {
+            @Override
+            public void run() {
+                callback.CompletionSurveySuccess(survey);
+            }
+        });
+    }
+
+    private void  notifyCompletionError(final Exception e){
+        mainExecutor.run(new Runnable() {
+            @Override
+            public void run() {
+                callback.CompletionSurveyError(e);
+            }
+        });
+    }
+
+    public interface CompletionSurveyCallback{
+        void CompletionSurveySuccess(Survey survey);
+        void CompletionSurveyError(Exception e);
     }
 }

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/layout/adapters/survey/SurveysAdapter.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/layout/adapters/survey/SurveysAdapter.java
@@ -133,7 +133,7 @@ public class SurveysAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 asterisk="*";
             }
 
-            String uid = context.getString(R.string.voucher) + ":" + survey.getVoucherUid();
+            String uid = context.getString(R.string.voucher) + ":" + survey.getVisibleVoucherUid();
 
             if (survey.noIssueVoucher()) {
                 uid = context.getString(R.string.no_voucher);

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/presentation/models/SurveyViewModel.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/presentation/models/SurveyViewModel.java
@@ -8,6 +8,7 @@ public class SurveyViewModel {
     private final Date eventDate;
     private final String uid;
     private final String voucherUid;
+    private final String visibleVoucherUid;
     private final boolean isCompleted;
     private final boolean hasPhone;
     private final boolean noIssueVoucher;
@@ -15,12 +16,13 @@ public class SurveyViewModel {
     private final List<String> visibleValues;
     private final int status;
 
-    public SurveyViewModel(Date eventDate, String uid, String voucherUid,
+    public SurveyViewModel(Date eventDate, String uid, String voucherUid,String visibleVoucherUid,
             boolean isCompleted, boolean hasPhone, boolean noIssueVoucher,
             List<String> importantValues, List<String> visibleValues, int status) {
         this.eventDate = eventDate;
         this.uid = uid;
         this.voucherUid = voucherUid;
+        this.visibleVoucherUid = visibleVoucherUid;
         this.isCompleted = isCompleted;
         this.hasPhone = hasPhone;
         this.noIssueVoucher = noIssueVoucher;
@@ -39,6 +41,10 @@ public class SurveyViewModel {
 
     public String getVoucherUid() {
         return voucherUid;
+    }
+
+    public String getVisibleVoucherUid() {
+        return visibleVoucherUid;
     }
 
     public boolean isCompleted() {

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/presentation/presenters/SurveysPresenter.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/presentation/presenters/SurveysPresenter.java
@@ -137,6 +137,7 @@ public class SurveysPresenter {
         Date eventDate = survey.getSurveyDate();
         String uid = survey.getUId();
         String voucherUid = survey.getVoucherUid();
+        String visibleVoucherUid = survey.getVisibleVoucherUid();
         boolean isCompleted = survey.isCompleted();
         boolean hasPhone = survey.hasPhone();
         boolean noIssueVoucher = survey.noIssueVoucher();
@@ -154,7 +155,7 @@ public class SurveysPresenter {
         }
 
         SurveyViewModel surveyViewModel =
-                new SurveyViewModel(eventDate, uid, voucherUid, isCompleted,
+                new SurveyViewModel(eventDate, uid, voucherUid, visibleVoucherUid, isCompleted,
                         hasPhone, noIssueVoucher, importantValues, visibleValues, status);
 
         return surveyViewModel;

--- a/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/DashboardActivityStrategy.java
+++ b/app/src/ereferrals/java/org/eyeseetea/malariacare/strategies/DashboardActivityStrategy.java
@@ -65,8 +65,6 @@ import org.eyeseetea.malariacare.domain.entity.UserAccount;
 import org.eyeseetea.malariacare.domain.exception.LoadingNavigationControllerException;
 import org.eyeseetea.malariacare.domain.exception.NetworkException;
 import org.eyeseetea.malariacare.domain.exception.NoFilesException;
-import org.eyeseetea.malariacare.domain.identifiers.CodeGenerator;
-import org.eyeseetea.malariacare.domain.identifiers.UIDGenerator;
 import org.eyeseetea.malariacare.domain.usecase.CompletionSurveyUseCase;
 import org.eyeseetea.malariacare.domain.usecase.DownloadMediaUseCase;
 import org.eyeseetea.malariacare.domain.usecase.GetAppInfoUseCase;
@@ -89,7 +87,6 @@ import org.eyeseetea.malariacare.services.strategies.PushServiceStrategy;
 import org.eyeseetea.malariacare.utils.Constants;
 
 import java.io.File;
-import java.util.Date;
 import java.util.List;
 
 public class DashboardActivityStrategy extends ADashboardActivityStrategy {
@@ -598,7 +595,7 @@ public class DashboardActivityStrategy extends ADashboardActivityStrategy {
 
     public void showEndSurveyMessage(SurveyDB surveyDB) {
         if (surveyDB != null && !noIssueVoucher(surveyDB) && !hasPhone(surveyDB)) {
-            final String voucherUId = surveyDB.getVisbleVoucherUid();
+            final String voucherUId = surveyDB.getVisibleVoucherUid();
 
             GetSettingsUseCase getSettingsUseCase = new GetSettingsUseCase(new UIThreadExecutor(),
                     new AsyncExecutor(),

--- a/app/src/ereferrals/res/layout/item_survey.xml
+++ b/app/src/ereferrals/res/layout/item_survey.xml
@@ -70,14 +70,14 @@
             android:orientation="horizontal"
             android:paddingLeft="6dp"
             android:paddingRight="6dp"
-            android:weightSum="2">
+            android:weightSum="1">
 
             <org.eyeseetea.sdk.presentation.views.CustomTextView
                 android:id="@+id/survey_hour"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:layout_weight="1"
+                android:layout_weight="0.25"
                 android:singleLine="true"
                 android:textAppearance="?android:attr/textAppearanceSmall"
                 android:textColor="@color/text_first_color"
@@ -89,7 +89,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="right"
                 android:gravity="right"
-                android:layout_weight="1"
+                android:layout_weight="0.75"
                 android:singleLine="true"
                 android:textAppearance="?android:attr/textAppearanceSmall"
                 android:textColor="@color/text_first_color"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,8 @@
         android:icon="@drawable/pictureapp_logo"
         android:label="@string/malaria_case_based_reporting"
         android:theme="@style/EyeSeeTheme"
-        tools:replace="android:allowBackup, android:icon">
+        tools:replace="android:allowBackup, android:icon"
+        android:usesCleartextTraffic="true">
 
         <service
             android:name=".services.MonitorService"

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/AppDatabase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/AppDatabase.java
@@ -31,7 +31,7 @@ import org.eyeseetea.malariacare.BuildConfig;
 
 public class AppDatabase {
     public static final String NAME = "EyeSeeTeaDB";
-    public static final int VERSION = 22;
+    public static final int VERSION = 23;
 
 
     // Aliases used for EyeSeeTea DB queries

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/AppDatabase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/AppDatabase.java
@@ -31,7 +31,7 @@ import org.eyeseetea.malariacare.BuildConfig;
 
 public class AppDatabase {
     public static final String NAME = "EyeSeeTeaDB";
-    public static final int VERSION = 23;
+    public static final int VERSION = 24;
 
 
     // Aliases used for EyeSeeTea DB queries

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/SurveyLocalDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/SurveyLocalDataSource.java
@@ -15,11 +15,9 @@ import org.eyeseetea.malariacare.domain.boundary.repositories.ISurveyRepository;
 import org.eyeseetea.malariacare.domain.entity.Question;
 import org.eyeseetea.malariacare.domain.entity.Survey;
 import org.eyeseetea.malariacare.domain.entity.Value;
-import org.eyeseetea.malariacare.domain.identifiers.CodeGenerator;
 import org.eyeseetea.malariacare.utils.Constants;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -157,6 +155,7 @@ public class SurveyLocalDataSource implements ISurveyRepository {
         surveyDB.setEventUid(survey.getUid());
         surveyDB.setStatus(survey.getStatus());
 
+
         surveyDB.update();
         setSurveyOnSession(surveyDB);
         return surveyDB.getId_survey();
@@ -234,7 +233,7 @@ public class SurveyLocalDataSource implements ISurveyRepository {
                 userDB.getUid(),
                 surveyDB.getType(),
                 values,
-                surveyDB.getVisbleVoucherUid());
+                surveyDB.getVisibleVoucherUid());
 
         return survey;
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/SurveyLocalDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/SurveyLocalDataSource.java
@@ -15,9 +15,11 @@ import org.eyeseetea.malariacare.domain.boundary.repositories.ISurveyRepository;
 import org.eyeseetea.malariacare.domain.entity.Question;
 import org.eyeseetea.malariacare.domain.entity.Survey;
 import org.eyeseetea.malariacare.domain.entity.Value;
+import org.eyeseetea.malariacare.domain.identifiers.CodeGenerator;
 import org.eyeseetea.malariacare.utils.Constants;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -148,7 +150,13 @@ public class SurveyLocalDataSource implements ISurveyRepository {
                     userDB, survey.getType());
             surveyDB.save();
         }
+
+        surveyDB.setEventDate(survey.getSurveyDate());
+        surveyDB.setVoucherUid(survey.getVoucherUid());
+        surveyDB.setVisibleVoucherUid(survey.getVisibleVoucherUid());
+        surveyDB.setEventUid(survey.getUid());
         surveyDB.setStatus(survey.getStatus());
+
         surveyDB.update();
         setSurveyOnSession(surveyDB);
         return surveyDB.getId_survey();
@@ -169,6 +177,13 @@ public class SurveyLocalDataSource implements ISurveyRepository {
             surveys.add(mapSurvey(surveyDB));
         }
         return surveys;
+    }
+
+    @Override
+    public Survey getSurveyByUid(String uid) {
+        SurveyDB surveyDB = SurveyDB.findByUid(uid);
+
+        return mapSurvey(surveyDB);
     }
 
     @Override
@@ -218,7 +233,8 @@ public class SurveyLocalDataSource implements ISurveyRepository {
                 orgUnitUid,
                 userDB.getUid(),
                 surveyDB.getType(),
-                values);
+                values,
+                surveyDB.getVisbleVoucherUid());
 
         return survey;
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/migrations/Migration23AddColumnsVoucherSuffix.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/migrations/Migration23AddColumnsVoucherSuffix.java
@@ -1,0 +1,22 @@
+package org.eyeseetea.malariacare.data.database.migrations;
+
+
+import com.raizlabs.android.dbflow.annotation.Migration;
+import com.raizlabs.android.dbflow.sql.SQLiteType;
+import com.raizlabs.android.dbflow.sql.migration.AlterTableMigration;
+
+import org.eyeseetea.malariacare.data.database.AppDatabase;
+import org.eyeseetea.malariacare.data.database.model.CountryVersionDB;
+import org.eyeseetea.malariacare.data.database.model.QuestionDB;
+
+@Migration(version = 23, database = AppDatabase.class)
+public class Migration23AddColumnsVoucherSuffix extends AlterTableMigration<QuestionDB> {
+
+    public Migration23AddColumnsVoucherSuffix(Class<QuestionDB> table) {
+        super(table);
+
+        addColumn(SQLiteType.TEXT, "voucher_suffix");
+        addColumn(SQLiteType.TEXT, "voucher_suffix_value_condition");
+    }
+
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/migrations/Migration24AddColumnVisibleVoucherUId.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/migrations/Migration24AddColumnVisibleVoucherUId.java
@@ -1,0 +1,21 @@
+package org.eyeseetea.malariacare.data.database.migrations;
+
+
+import com.raizlabs.android.dbflow.annotation.Migration;
+import com.raizlabs.android.dbflow.sql.SQLiteType;
+import com.raizlabs.android.dbflow.sql.migration.AlterTableMigration;
+
+import org.eyeseetea.malariacare.data.database.AppDatabase;
+import org.eyeseetea.malariacare.data.database.model.QuestionDB;
+import org.eyeseetea.malariacare.data.database.model.SurveyDB;
+
+@Migration(version = 24, database = AppDatabase.class)
+public class Migration24AddColumnVisibleVoucherUId extends AlterTableMigration<SurveyDB> {
+
+    public Migration24AddColumnVisibleVoucherUId(Class<SurveyDB> table) {
+        super(table);
+
+        addColumn(SQLiteType.TEXT, "visible_voucher_uid");
+    }
+
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/model/QuestionDB.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/model/QuestionDB.java
@@ -191,6 +191,12 @@ public class QuestionDB extends BaseModel {
     @Column
     boolean disabled;
 
+    @Column
+    String voucher_suffix;
+
+    @Column
+    String voucher_suffix_value_condition;
+
     public List<OptionDB> getOptionDBS() {
         return optionDBS;
     }
@@ -908,6 +914,23 @@ public class QuestionDB extends BaseModel {
         this.mCompositeScoreDB = compositeScoreDB;
         this.id_composite_score_fk =
                 (compositeScoreDB != null) ? compositeScoreDB.getId_composite_score() : null;
+    }
+
+
+    public String getVoucher_suffix() {
+        return voucher_suffix;
+    }
+
+    public void setVoucher_suffix(String voucher_suffix) {
+        this.voucher_suffix = voucher_suffix;
+    }
+
+    public String getVoucher_suffix_value_condition() {
+        return voucher_suffix_value_condition;
+    }
+
+    public void setVoucher_suffix_value_condition(String voucher_suffix_value_condition) {
+        this.voucher_suffix_value_condition = voucher_suffix_value_condition;
     }
 
     public List<QuestionRelationDB> getQuestionRelationDBs() {

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/model/SurveyDB.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/model/SurveyDB.java
@@ -127,6 +127,9 @@ public class SurveyDB extends BaseModel implements VisitableToSDK {
     @Column
     String voucher_uid;
 
+    @Column
+    String visible_voucher_uid;
+
     /**
      * List of values for this survey
      */
@@ -337,6 +340,13 @@ public class SurveyDB extends BaseModel implements VisitableToSDK {
     }
     public void setVoucherUid(String eventuid) {
         this.voucher_uid = eventuid;
+    }
+
+    public String getVisbleVoucherUid() {
+        return visible_voucher_uid;
+    }
+    public void setVisibleVoucherUid(String eventuid) {
+        this.visible_voucher_uid = eventuid;
     }
     /**
      * Returns a concrete survey, if it exists

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/model/SurveyDB.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/model/SurveyDB.java
@@ -343,15 +343,16 @@ public class SurveyDB extends BaseModel implements VisitableToSDK {
     public String getVoucherUid() {
         return voucher_uid;
     }
-    public void setVoucherUid(String eventuid) {
-        this.voucher_uid = eventuid;
+
+    public void setVoucherUid(String value) {
+        this.voucher_uid = value;
     }
 
-    public String getVisbleVoucherUid() {
+    public String getVisibleVoucherUid() {
         return visible_voucher_uid;
     }
-    public void setVisibleVoucherUid(String eventuid) {
-        this.visible_voucher_uid = eventuid;
+    public void setVisibleVoucherUid(String value) {
+        this.visible_voucher_uid = value;
     }
     /**
      * Returns a concrete survey, if it exists

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/model/SurveyDB.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/model/SurveyDB.java
@@ -62,6 +62,7 @@ import org.eyeseetea.malariacare.data.sync.exporter.VisitableToSDK;
 import org.eyeseetea.malariacare.domain.boundary.repositories.IProgramRepository;
 import org.eyeseetea.malariacare.domain.entity.SurveyAnsweredRatio;
 import org.eyeseetea.malariacare.domain.exception.ConversionException;
+import org.eyeseetea.malariacare.domain.identifiers.CodeGenerator;
 import org.eyeseetea.malariacare.strategies.SurveyFragmentStrategy;
 import org.eyeseetea.malariacare.utils.Constants;
 import org.joda.time.DateTime;
@@ -157,6 +158,10 @@ public class SurveyDB extends BaseModel implements VisitableToSDK {
         this.event_date = new Date();
         this.scheduled_date = null;
         this.type = Constants.SURVEY_NO_TYPE; //to avoid NullPointerExceptions
+
+        // TODO: This action should be make on survey entity creation when create a new survey
+        //but domain entity is not used the first time
+        this.uid_event_fk = CodeGenerator.generateCode();
     }
 
     public SurveyDB(OrgUnitDB orgUnitDB, ProgramDB programDB, UserDB userDB) {

--- a/app/src/main/java/org/eyeseetea/malariacare/data/mappers/QuestionConvertFromDomainVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/mappers/QuestionConvertFromDomainVisitor.java
@@ -53,6 +53,13 @@ public class QuestionConvertFromDomainVisitor implements
         dbModel.setValidationMessage(domainModel.getRegExpError());
         dbModel.setPhoneFormatDB(getPhoneFormat(domainModel.getPhoneFormat()));
         dbModel.setDefaultValue(domainModel.getDefaultValue());
+
+        if (domainModel.getVoucherCodeSuffix() != null) {
+            dbModel.setVoucher_suffix(domainModel.getVoucherCodeSuffix().suffix);
+            dbModel.setVoucher_suffix_value_condition(
+                    domainModel.getVoucherCodeSuffix().valueCondition);
+        }
+
         return dbModel;
     }
 
@@ -138,7 +145,7 @@ public class QuestionConvertFromDomainVisitor implements
                 break;
 
             case AUTOCOMPLETE_TEXT:
-                finalOutput=Constants.AUTOCOMPLETE_TEXT;
+                finalOutput = Constants.AUTOCOMPLETE_TEXT;
                 break;
 
         }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/mappers/QuestionMapper.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/mappers/QuestionMapper.java
@@ -49,6 +49,9 @@ public class QuestionMapper {
                     .regExp(questionDB.getValidationRegExp())
                     .regExpError(questionDB.getValidationMessage())
                     .compulsory(questionDB.isCompulsory())
+                    .voucherCodeSuffix(new Question.VoucherCodeSuffix(
+                            questionDB.getVoucher_suffix(),
+                            questionDB.getVoucher_suffix_value_condition()))
                     .build();
         }else{
             return Question.newBuilder()
@@ -62,6 +65,9 @@ public class QuestionMapper {
                     .regExpError(questionDB.getValidationMessage())
                     .compulsory(questionDB.isCompulsory())
                     .value(value)
+                    .voucherCodeSuffix(new Question.VoucherCodeSuffix(
+                            questionDB.getVoucher_suffix(),
+                            questionDB.getVoucher_suffix_value_condition()))
                     .build();
         }
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/boundary/repositories/ISurveyRepository.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/boundary/repositories/ISurveyRepository.java
@@ -24,6 +24,7 @@ public interface ISurveyRepository {
     List<Survey> getAllCompletedSurveys();
 
     List<Survey> getSurveysByProgram(String idProgram);
+    Survey getSurveyByUid(String uid);
 
     Survey createNewSurvey();
 

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Question.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Question.java
@@ -25,13 +25,14 @@ public class Question {
     private String regExp;
     private String regExpError;
     private String defaultValue;
+    private VoucherCodeSuffix voucherCodeSuffix;
 
     public Question(long id, String code, String name, String uid,
             PhoneFormat phoneFormat, Type type, boolean compulsory,
             boolean disabled, List<Option> options, Header header, int index,
             Visibility visibility,
             List<Rule> rules, Value value, String regExp,
-            String regExpError, String defaultValue) {
+            String regExpError, String defaultValue, VoucherCodeSuffix voucherCodeSuffix) {
 
         this.id = required(id, "id is required");
         this.code = required(code, "code is required");
@@ -50,6 +51,7 @@ public class Question {
         this.regExp = regExp;
         this.regExpError = regExpError;
         this.defaultValue = defaultValue;
+        this.voucherCodeSuffix = voucherCodeSuffix;
     }
 
     public static Builder newBuilder() {
@@ -130,6 +132,10 @@ public class Question {
 
     public String getDefaultValue(){ return defaultValue;}
 
+    public VoucherCodeSuffix getVoucherCodeSuffix() {
+        return voucherCodeSuffix;
+    }
+
     public void match(String value) throws RegExpValidationException {
         if (!value.matches(regExp)){
             throw new RegExpValidationException(value);
@@ -164,6 +170,11 @@ public class Question {
             return false;
         }
         if (visibility != question.visibility) return false;
+
+        if (voucherCodeSuffix != null ? !voucherCodeSuffix.equals(question.voucherCodeSuffix) : question.voucherCodeSuffix != null) {
+            return false;
+        }
+
         return rules != null ? rules.equals(question.rules) : question.rules == null;
     }
 
@@ -184,6 +195,7 @@ public class Question {
         result = 31 * result + index;
         result = 31 * result + (visibility != null ? visibility.hashCode() : 0);
         result = 31 * result + (rules != null ? rules.hashCode() : 0);
+        result = 31 * result + (voucherCodeSuffix != null ? voucherCodeSuffix.hashCode() : 0);
         return result;
     }
 
@@ -205,6 +217,7 @@ public class Question {
                 ", regExp=" + regExp +
                 ", regExpError=" + regExpError +
                 ", defaultValue=" + defaultValue +
+                ", voucherCodeSuffix=" + voucherCodeSuffix +
                 '}';
     }
 
@@ -236,6 +249,7 @@ public class Question {
         private String regExpError;
         private String defaultValue;
         private boolean disabled;
+        private VoucherCodeSuffix voucherCodeSuffix;
 
         public Builder() {
         }
@@ -319,6 +333,12 @@ public class Question {
             defaultValue = val;
             return this;
         }
+
+        public Builder voucherCodeSuffix(VoucherCodeSuffix voucherCodeSuffix) {
+            this.voucherCodeSuffix = voucherCodeSuffix;
+            return this;
+        }
+
         public Question build() {
             return new Question(
                     this.id,
@@ -337,13 +357,43 @@ public class Question {
                     mValue,
                     this.regExp,
                     this.regExpError,
-                    this.defaultValue
+                    this.defaultValue,
+                    this.voucherCodeSuffix
             );
         }
 
         public Builder id(long val) {
             id = val;
             return this;
+        }
+    }
+
+    public static class VoucherCodeSuffix {
+        public String suffix;
+        public String valueCondition;
+
+        public VoucherCodeSuffix(String suffix, String valueCondition) {
+            this.suffix = suffix;
+            this.valueCondition = valueCondition;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            VoucherCodeSuffix that = (VoucherCodeSuffix) o;
+
+            if (suffix != null ? !suffix.equals(that.suffix) : that.suffix != null) return false;
+            return valueCondition != null ? valueCondition.equals(that.valueCondition)
+                    : that.valueCondition == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = suffix != null ? suffix.hashCode() : 0;
+            result = 31 * result + (valueCondition != null ? valueCondition.hashCode() : 0);
+            return result;
         }
     }
 

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Survey.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/Survey.java
@@ -20,11 +20,12 @@ public class Survey {
     private int mType;
     private List<Value> values;
     private String voucherUid;
+    private String visibleVoucherUid;
 
     public Survey(long id, String uid, String voucherUid, int status,
             SurveyAnsweredRatio surveyAnsweredRatio, Date surveyDate,
             String programUid, String orgUnitUid, String userUid, int type,
-            List<Value> values) {
+            List<Value> values, String visibleVoucherUid) {
         this.id = id;
         this.uid = uid;
         this.voucherUid = voucherUid;
@@ -36,6 +37,7 @@ public class Survey {
         this.userUid = userUid;
         this.mType = required(type, "Type is required");
         this.values = values;
+        this.visibleVoucherUid = visibleVoucherUid;
     }
 
     public Survey(String programUid, String orgUnitUid, String userUid, int type) {
@@ -79,6 +81,10 @@ public class Survey {
         return uid;
     }
 
+    public void assignUid(String uid) {
+        this.uid = uid;
+    }
+
     public String getProgramUid() {
         return programUid;
     }
@@ -117,12 +123,27 @@ public class Survey {
         return mSurveyDate;
     }
 
+    public void changeEventDate(Date date) {
+        mSurveyDate = date;
+    }
+
     public String getUId() {
         return uid;
     }
 
     public String getVoucherUid() {
         return voucherUid;
+    }
+
+    public void assignVoucherUid(String voucherUid) {
+        this.voucherUid = voucherUid;
+    }
+
+    public String getVisibleVoucherUid() {
+        return visibleVoucherUid;
+    }
+    public void assignVisibleVoucherUid(String visibleVoucherUid) {
+        this.visibleVoucherUid = visibleVoucherUid;
     }
 
     public boolean isCompleted() {

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/ACompletionSurveyUseCase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/usecase/ACompletionSurveyUseCase.java
@@ -2,6 +2,6 @@ package org.eyeseetea.malariacare.domain.usecase;
 
 public abstract class ACompletionSurveyUseCase {
 
-    public abstract void execute(long idSurvey);
+    public abstract void execute(String surveyUid);
 
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/factories/SurveyFactory.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/factories/SurveyFactory.java
@@ -1,9 +1,11 @@
 package org.eyeseetea.malariacare.factories;
 
+import org.eyeseetea.malariacare.data.database.datasources.QuestionLocalDataSource;
 import org.eyeseetea.malariacare.data.database.datasources.SurveyLocalDataSource;
 import org.eyeseetea.malariacare.domain.boundary.executors.IAsyncExecutor;
 import org.eyeseetea.malariacare.domain.boundary.executors.IMainExecutor;
 import org.eyeseetea.malariacare.domain.boundary.repositories.ISurveyRepository;
+import org.eyeseetea.malariacare.domain.usecase.CompletionSurveyUseCase;
 import org.eyeseetea.malariacare.domain.usecase.DeleteSurveyByUidUseCase;
 import org.eyeseetea.malariacare.domain.usecase.GetSurveysByProgram;
 import org.eyeseetea.malariacare.presentation.executors.AsyncExecutor;
@@ -27,5 +29,11 @@ public class SurveyFactory {
                 new DeleteSurveyByUidUseCase(asyncExecutor, mainExecutor, surveyRepository);
 
         return deleteSurveyByUidUseCase;
+    }
+
+    public CompletionSurveyUseCase getCompletionSurveyUseCase() {
+
+        return new CompletionSurveyUseCase(asyncExecutor, mainExecutor, new SurveyLocalDataSource(),
+                new QuestionLocalDataSource());
     }
 }

--- a/app/src/sharedTest/java/org/eyeseetea/malariacare/configurationimporter/ConstantsMetadataConfigurationImporterTest.java
+++ b/app/src/sharedTest/java/org/eyeseetea/malariacare/configurationimporter/ConstantsMetadataConfigurationImporterTest.java
@@ -16,6 +16,9 @@ public class ConstantsMetadataConfigurationImporterTest {
     public static final String NP_CONFIG_FILE_JSON =
             "np_config_file.json";
 
+    public static final String HN_CONFIG_FILE_JSON =
+            "hn_config_file.json";
+
     public static final String MZ_CONFIG_ANDROID_2_0_JSON =
             "mz_config_android_2_0.json";
 

--- a/app/src/testEreferrals/java/org/eyeseetea/malariacare/data/database/convert/QuestionConvertFromDomainVisitorShould.java
+++ b/app/src/testEreferrals/java/org/eyeseetea/malariacare/data/database/convert/QuestionConvertFromDomainVisitorShould.java
@@ -30,6 +30,17 @@ public class QuestionConvertFromDomainVisitorShould {
     }
 
     @Test
+    public void convert_a_domain_question_with_suffix() {
+
+        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionOneOptionAndSuffix());
+
+        QuestionDB expectedQuestion = givenADBQuestionWithOneOption();
+
+        assertEqual(questionToEvaluate, expectedQuestion);
+
+    }
+
+    @Test
     public void convert_a_domain_question_with_one_options_to_questiondb_with_one_question_answer
             () {
 
@@ -59,7 +70,7 @@ public class QuestionConvertFromDomainVisitorShould {
     public void convert_a_domain_question_to_questiondb_with_empty_default_value()
             throws Exception {
 
-        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWith(
+        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWithDefaultValue(
                 ""));
 
         QuestionDB expectedQuestion = givenADBQuestionWithDefaultValue("");
@@ -73,7 +84,7 @@ public class QuestionConvertFromDomainVisitorShould {
             throws Exception {
 
         String defaultValue = "defaultValue";
-        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWith(
+        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWithDefaultValue(
                 defaultValue));
 
         QuestionDB expectedQuestion = givenADBQuestionWithDefaultValue(defaultValue);
@@ -81,11 +92,12 @@ public class QuestionConvertFromDomainVisitorShould {
         assertEqual(questionToEvaluate, expectedQuestion);
 
     }
+
     @Test
     public void convert_a_domain_question_to_questiondb_with_dropdown_list_output()
             throws Exception {
 
-        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWith(
+        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWithType(
                 Question.Type.DROPDOWN_LIST));
 
         QuestionDB expectedQuestion = givenADBQuestionWithOutput(Constants.DROPDOWN_OU_LIST);
@@ -98,10 +110,11 @@ public class QuestionConvertFromDomainVisitorShould {
     public void convert_a_domain_question_to_questiondb_with_regexp_and_regexp_error()
             throws Exception {
 
-        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWith(
+        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWithRegex(
                 "^(\\d{2})$", "some_error_msg_ref\""));
 
-        QuestionDB expectedQuestion =  givenADBQuestionWithValidation( "^(\\d{2})$", "some_error_msg_ref\"");
+        QuestionDB expectedQuestion = givenADBQuestionWithValidation("^(\\d{2})$",
+                "some_error_msg_ref\"");
 
         assertEqual(questionToEvaluate, expectedQuestion);
     }
@@ -109,7 +122,7 @@ public class QuestionConvertFromDomainVisitorShould {
     @Test
     public void convert_a_domain_question_to_questiondb_with_short_text_output() throws Exception {
 
-        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWith(
+        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWithType(
                 Question.Type.SHORT_TEXT));
 
         QuestionDB expectedQuestion = givenADBQuestionWithOutput(Constants.SHORT_TEXT);
@@ -120,7 +133,7 @@ public class QuestionConvertFromDomainVisitorShould {
     @Test
     public void convert_a_domain_question_to_questiondb_with_phone_output() throws Exception {
 
-        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWith(
+        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWithType(
                 Question.Type.PHONE));
 
         QuestionDB expectedQuestion = givenADBQuestionWithOutput(Constants.PHONE);
@@ -132,7 +145,7 @@ public class QuestionConvertFromDomainVisitorShould {
     @Test
     public void convert_a_domain_question_to_questiondb_with_year_output() throws Exception {
 
-        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWith(
+        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWithType(
                 Question.Type.YEAR));
 
         QuestionDB expectedQuestion = givenADBQuestionWithOutput(Constants.YEAR);
@@ -144,7 +157,7 @@ public class QuestionConvertFromDomainVisitorShould {
     @Test
     public void convert_a_domain_question_to_questiondb_with_date_output() throws Exception {
 
-        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWith(
+        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWithType(
                 Question.Type.DATE));
 
         QuestionDB expectedQuestion = givenADBQuestionWithOutput(Constants.DATE);
@@ -156,7 +169,7 @@ public class QuestionConvertFromDomainVisitorShould {
     @Test
     public void convert_a_domain_question_to_questiondb_with_long_output() throws Exception {
 
-        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWith(
+        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWithType(
                 Question.Type.LONG_TEXT));
 
         QuestionDB expectedQuestion = givenADBQuestionWithOutput(Constants.LONG_TEXT);
@@ -169,7 +182,7 @@ public class QuestionConvertFromDomainVisitorShould {
     public void convert_a_domain_question_to_questiondb_with_positive_int_output()
             throws Exception {
 
-        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWith(
+        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWithType(
                 Question.Type.POSITIVE_INT));
 
         QuestionDB expectedQuestion = givenADBQuestionWithOutput(Constants.POSITIVE_INT);
@@ -182,7 +195,7 @@ public class QuestionConvertFromDomainVisitorShould {
     public void convert_a_domain_question_to_questiondb_with_pregnant_month_int_output()
             throws Exception {
 
-        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWith(
+        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWithType(
                 Question.Type.PREGNANT_MONTH));
 
         QuestionDB expectedQuestion = givenADBQuestionWithOutput(Constants.PREGNANT_MONTH_INT);
@@ -195,7 +208,7 @@ public class QuestionConvertFromDomainVisitorShould {
     public void convert_a_domain_question_to_questiondb_with_radio_group_horizontal_output()
             throws Exception {
 
-        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWith(
+        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWithType(
                 Question.Type.RADIO_GROUP_HORIZONTAL));
 
         QuestionDB expectedQuestion = givenADBQuestionWithOutput(Constants.RADIO_GROUP_HORIZONTAL);
@@ -208,7 +221,7 @@ public class QuestionConvertFromDomainVisitorShould {
     public void convert_a_domain_question_to_questiondb_with_question_label_output()
             throws Exception {
 
-        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWith(
+        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWithType(
                 Question.Type.QUESTION_LABEL));
 
         QuestionDB expectedQuestion = givenADBQuestionWithOutput(Constants.QUESTION_LABEL);
@@ -221,7 +234,7 @@ public class QuestionConvertFromDomainVisitorShould {
     public void convert_a_domain_question_to_questiondb_with_switch_button_output()
             throws Exception {
 
-        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWith(
+        QuestionDB questionToEvaluate = converter.visit(givenADomainQuestionWithType(
                 Question.Type.SWITCH_BUTTON));
 
         QuestionDB expectedQuestion = givenADBQuestionWithOutput(Constants.SWITCH_BUTTON);
@@ -266,48 +279,42 @@ public class QuestionConvertFromDomainVisitorShould {
 
     }
 
-    private Question givenADomainQuestionWith(Question.Type type) {
-        Question question = Question
-                .newBuilder()
-                .uid("uid")
-                .code("program")
-                .name("ipc_issueEntry_q_program")
-                .type(Question.Type.DROPDOWN_LIST)
-                .visibility(Question.Visibility.VISIBLE)
-                .type(type)
-                .compulsory(true).build();
+    private Question givenADomainQuestionWithType(Question.Type type) {
+        return givenADomainQuestion(null, null, type, null, null, null);
+    }
 
+    private Question givenADomainQuestionWithDefaultValue(String defaultValue) {
+        return givenADomainQuestion(null, null, Question.Type.DROPDOWN_LIST, defaultValue, null,
+                null);
+    }
+
+    private Question givenADomainQuestionWithRegex(String regexp, String regExpError) {
+        return givenADomainQuestion(null, null, Question.Type.DROPDOWN_LIST,
+                null, regexp, regExpError);
+    }
+
+    private Question givenADomainQuestionOneOptionAndSuffix() {
+        List<Option> options = new ArrayList<>(1);
+
+        Option firstOption = Option.newBuilder()
+                .code("YES")
+                .name("ipc_issueEntry_q_blank")
+                .build();
+
+        options.add(firstOption);
+
+        Question.VoucherCodeSuffix suffix =
+                new Question.VoucherCodeSuffix("MAC", "YES");
+
+        Question question = givenADomainQuestion(options, suffix, Question.Type.DROPDOWN_LIST,
+                null, null, null);
 
         return question;
     }
-    private Question givenADomainQuestionWith(String defaultValue) {
-        Question question = Question
-                .newBuilder()
-                .uid("uid")
-                .code("program")
-                .name("ipc_issueEntry_q_program")
-                .type(Question.Type.DROPDOWN_LIST)
-                .visibility(Question.Visibility.VISIBLE)
-                .defaultValue(defaultValue)
-                .compulsory(true).build();
 
-
-        return question;
-    }
-
-    private Question givenADomainQuestionWith(String regexp, String regExpError) {
-        Question question = Question
-                .newBuilder()
-                .uid("uid")
-                .code("program")
-                .name("ipc_issueEntry_q_program")
-                .type(Question.Type.DROPDOWN_LIST)
-                .visibility(Question.Visibility.VISIBLE)
-                .regExp(regexp)
-                .regExpError(regExpError)
-                .compulsory(true).build();
-
-
+    private Question givenADomainQuestionWithVisibility(Question.Visibility visibility) {
+        Question question = givenADomainQuestionBuilderWithNonOptions();
+        question.setVisibility(visibility);
         return question;
     }
 
@@ -321,22 +328,33 @@ public class QuestionConvertFromDomainVisitorShould {
 
         options.add(firstOption);
 
+        return givenADomainQuestion(options, null, Question.Type.DROPDOWN_LIST, null, null,
+                null);
+    }
+
+    private Question givenADomainQuestionBuilderWithNonOptions() {
+        return givenADomainQuestion(null, null, Question.Type.DROPDOWN_LIST, null, null,
+                null);
+    }
+
+    private Question givenADomainQuestion(List<Option> options, Question.VoucherCodeSuffix suffix,
+            Question.Type type, String defaultValue, String regexp, String regExpError) {
+
         Question question = Question
                 .newBuilder()
                 .uid("uid")
                 .code("program")
                 .name("ipc_issueEntry_q_program")
-                .type(Question.Type.DROPDOWN_LIST)
+                .type(type)
                 .visibility(Question.Visibility.VISIBLE)
                 .options(options)
-                .compulsory(true).build();
+                .compulsory(true)
+                .defaultValue(defaultValue)
+                .regExp(regexp)
+                .regExpError(regExpError)
+                .voucherCodeSuffix(suffix)
+                .build();
 
-        return question;
-    }
-
-    private Question givenADomainQuestionWithVisibility(Question.Visibility visibility) {
-        Question question = givenADomainQuestionBuilderWithNonOptions();
-        question.setVisibility(visibility);
         return question;
     }
 
@@ -353,22 +371,30 @@ public class QuestionConvertFromDomainVisitorShould {
         return questionDB;
     }
 
-    private Question givenADomainQuestionBuilderWithNonOptions() {
-        return Question
-                .newBuilder()
-                .uid("uid")
-                .code("program")
-                .name("ipc_issueEntry_q_program")
-                .type(Question.Type.DROPDOWN_LIST)
-                .visibility(Question.Visibility.VISIBLE)
-                .compulsory(true).build();
+    private QuestionDB givenADBQuestionWithOneOptionAndSuffix() {
+        QuestionDB questionDB = givenAQuestionDB();
+
+        OptionDB optionDB = new OptionDB();
+
+        optionDB.setCode("YES");
+        optionDB.setName("ipc_issueEntry_q_blank");
+
+        QuestionOptionDB questionOptionDB = new QuestionOptionDB();
+        questionOptionDB.setOption(optionDB);
+
+        questionDB.setVoucher_suffix("MAC");
+        questionDB.setVoucher_suffix_value_condition("YES");
+
+        return questionDB;
     }
+
 
     private QuestionDB givenADBQuestionWithOutput(int output) {
         QuestionDB question = givenAQuestionDB();
         question.setOutput(output);
         return question;
     }
+
     private QuestionDB givenADBQuestionWithDefaultValue(String defaultValue) {
         QuestionDB question = givenAQuestionDB();
         question.setDefaultValue(defaultValue);

--- a/app/src/testEreferrals/java/org/eyeseetea/malariacare/data/sync/importer/MetadataConfigurationApiClientShould.java
+++ b/app/src/testEreferrals/java/org/eyeseetea/malariacare/data/sync/importer/MetadataConfigurationApiClientShould.java
@@ -2,6 +2,7 @@ package org.eyeseetea.malariacare.data.sync.importer;
 
 import static org.eyeseetea.malariacare.configurationimporter
         .ConstantsMetadataConfigurationImporterTest.COUNTRIES_VERSION;
+import static org.eyeseetea.malariacare.configurationimporter.ConstantsMetadataConfigurationImporterTest.HN_CONFIG_FILE_JSON;
 import static org.eyeseetea.malariacare.configurationimporter
         .ConstantsMetadataConfigurationImporterTest.MZ_CONFIG_FILE_JSON;
 import static org.eyeseetea.malariacare.configurationimporter
@@ -59,6 +60,14 @@ public class MetadataConfigurationApiClientShould {
     }
 
     @Test
+    public void parse_hn_configuration_response() throws Exception {
+
+        whenRequestQuestionsForHNCountry();
+
+        thenAssertThatResponseParseSuccessfullyForHNCountry();
+    }
+
+    @Test
     public void parse_tz_configuration_response() throws Exception {
 
         whenRequestQuestionsForTZCountry();
@@ -107,6 +116,10 @@ public class MetadataConfigurationApiClientShould {
     }
 
 
+    private void thenAssertThatResponseParseSuccessfullyForHNCountry() {
+        validateQuestion(questions.get(20), givenAValidQuestionForHN());
+    }
+
     private void thenAssertThatResponseParseSuccessfullyForMZCountry() {
         validateQuestion(questions.get(0), givenAValidQuestionForMZ());
     }
@@ -136,6 +149,10 @@ public class MetadataConfigurationApiClientShould {
     private void enqueueMalformedJson() throws IOException {
         mockWebServerRule.getMockServer().enqueueMockResponse(200, "{malformedJson}");
 
+    }
+
+    private void whenRequestQuestionsForHNCountry() throws Exception {
+        requestQuestionsFor(HN_CONFIG_FILE_JSON, "hn@MZ@v1");
     }
 
     private void whenRequestQuestionsForMZCountry() throws Exception {
@@ -181,6 +198,8 @@ public class MetadataConfigurationApiClientShould {
 
         assertThat(questionToValidate.isCompulsory(), is(expectedQuestion.isCompulsory()));
 
+        assertThat(questionToValidate.getVoucherCodeSuffix(), is(expectedQuestion.getVoucherCodeSuffix()));
+
         if (expectedQuestion.getOptions() != null) {
             assertThat(questionToValidate.getOptions(), is(notNullValue()));
 
@@ -193,6 +212,30 @@ public class MetadataConfigurationApiClientShould {
                 assertThat(toValidateOption.getName(), is(validOption.getName()));
             }
         }
+    }
+
+    private Question givenAValidQuestionForHN() {
+
+        Question mzQuestion = Question.
+                newBuilder()
+                .uid("uid")
+                .code("serviceDesired_medcons")
+                .name("common_option_serviceDesired_medcons")
+                .type(Question.Type.RADIO_GROUP_HORIZONTAL)
+                .compulsory(false)
+                .options(new ArrayList<Option>(1))
+                .voucherCodeSuffix(new Question.VoucherCodeSuffix("SSR", "YES"))
+                .build();
+
+        Option firstOption = Option
+                .newBuilder()
+                .code("YES")
+                .name("ipc_issueEntry_q_blank")
+                .build();
+
+        mzQuestion.getOptions().add(firstOption);
+
+        return mzQuestion;
     }
 
     private Question givenAValidQuestionForMZ() {

--- a/app/src/testEreferrals/java/org/eyeseetea/malariacare/domain/service/VoucherSuffixDomainServiceShould.java
+++ b/app/src/testEreferrals/java/org/eyeseetea/malariacare/domain/service/VoucherSuffixDomainServiceShould.java
@@ -1,0 +1,120 @@
+package org.eyeseetea.malariacare.domain.service;
+
+import static android.net.sip.SipErrorCode.IN_PROGRESS;
+
+import org.eyeseetea.malariacare.domain.entity.Question;
+import org.eyeseetea.malariacare.domain.entity.Survey;
+import org.eyeseetea.malariacare.domain.entity.SurveyAnsweredRatio;
+import org.eyeseetea.malariacare.domain.entity.Value;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+public class VoucherSuffixDomainServiceShould {
+
+    @Test
+    public void return_suffix_if_value_condition_is_equal() {
+        List<Question> questions = givenAQuestionsWithSuffix(Arrays.asList("", "MAC", "STR"));
+
+        Survey survey = givenASurveyForQuestions(questions, "YES");
+
+        VoucherSuffixDomainService voucherSuffixDomainService = new VoucherSuffixDomainService();
+
+        String suffix = voucherSuffixDomainService.calculate(survey, questions);
+
+        Assert.assertEquals("_MAC_STR", suffix);
+    }
+
+    @Test
+    public void return_empty_suffix_if_value_condition_is_not_equal() {
+        List<Question> questions = givenAQuestionsWithSuffix(Arrays.asList("", "MAC", "STR"));
+
+        Survey survey = givenASurveyForQuestions(questions, "NO");
+
+        VoucherSuffixDomainService voucherSuffixDomainService = new VoucherSuffixDomainService();
+
+        String suffix = voucherSuffixDomainService.calculate(survey, questions);
+
+        Assert.assertEquals("", suffix);
+    }
+
+    @Test
+    public void return_empty_suffix_if_does_not_exists_questions_with_suffix() {
+        List<Question> questions = givenAQuestionsWithSuffix(Arrays.asList("", "", ""));
+
+        Survey survey = givenASurveyForQuestions(questions,"YES");
+
+        VoucherSuffixDomainService voucherSuffixDomainService = new VoucherSuffixDomainService();
+
+        String suffix = voucherSuffixDomainService.calculate(survey, questions);
+
+        Assert.assertEquals("", suffix);
+    }
+
+    private List<Question> givenAQuestionsWithSuffix(List<String> suffixesForQuestions) {
+        List<Question> questions = new ArrayList<>();
+
+        int count = 0;
+
+        for (String suffix : suffixesForQuestions) {
+            if (suffix.isEmpty()) {
+                questions.add(Question.newBuilder()
+                        .code("Code")
+                        .id(count)
+                        .uid(String.valueOf(count))
+                        .name(String.valueOf(count))
+                        .type(Question.Type.SHORT_TEXT)
+                        .build());
+            } else {
+                questions.add(Question.newBuilder()
+                        .code("Code")
+                        .id(count)
+                        .uid(String.valueOf(count))
+                        .name(String.valueOf(count))
+                        .type(Question.Type.RADIO_GROUP_HORIZONTAL)
+                        .voucherCodeSuffix(new Question.VoucherCodeSuffix(suffix, "YES"))
+                        .build());
+            }
+
+            count++;
+        }
+
+        return questions;
+    }
+
+
+    private Survey givenASurveyForQuestions(List<Question> questions, String valueForSuffixQuestions) {
+        long id = 1;
+        String uid = "Uid";
+        String voucherUid = "voucherUid";
+        int status = IN_PROGRESS;
+        SurveyAnsweredRatio surveyAnsweredRatio = null;
+        Date surveyDate = new Date();
+        String programUid = "programUid";
+        String orgUnitUid = "orgUnitUid";
+        String userUid = "userUid";
+        int type = 1;
+        List<Value> values = new ArrayList<>();
+        String visibleVoucherUid = null;
+
+        for (Question question : questions) {
+            Value value;
+            if (question.getVoucherCodeSuffix() != null) {
+                value = new Value(valueForSuffixQuestions, question.getUid());
+            } else {
+                value = new Value("text", question.getUid());
+            }
+
+            values.add(value);
+        }
+
+        Survey survey = new Survey(id, uid, voucherUid, status, surveyAnsweredRatio, surveyDate,
+                programUid, orgUnitUid, userUid, type, values, visibleVoucherUid);
+
+        return survey;
+    }
+}

--- a/app/src/testEreferrals/resources/hn_config_file.json
+++ b/app/src/testEreferrals/resources/hn_config_file.json
@@ -1,0 +1,952 @@
+{
+  "countryCode": "HN",
+  "program": "FPL",
+  "actionType": "issueReferral",
+  "version": "2",
+  "updateDate": "2019-06-12 12:00",
+  "updateUser": "BR",
+  "languages": [
+    "en"
+  ],
+  "issuing_capture": {
+    "payloadSpecs": [
+      {
+        "dataPointRef": "url"
+      },
+      {
+        "dataPointRef": "version"
+      },
+      {
+        "dataPointRef": "csvVersion",
+        "mandatory": "false"
+      },
+      {
+        "dataPointRef": "source"
+      },
+      {
+        "dataPointRef": "androidInfo",
+        "mandatory": "false"
+      },
+      {
+        "dataPointRef": "language"
+      },
+      {
+        "dataPointRef": "userName"
+      },
+      {
+        "dataPointRef": "password"
+      },
+      {
+        "dataPointRef": "settings",
+        "mandatory": "false"
+      }
+    ],
+    "actionsSpecs": [
+      {
+        "dataPointRef": "type"
+      },
+      {
+        "dataPointRef": "actionId"
+      },
+      {
+        "dataPointRef": "sourceAddedDateTime"
+      },
+      {
+        "dataPointRef": "voucher"
+      },
+      {
+        "dataPointRef": "coordinates"
+      }
+    ],
+    "dataValuesSpecs": [
+      {
+        "dataPointRef": "program",
+        "poTerm": "ipc_issueEntry_q_program",
+        "defaultName": "Program",
+        "controlType": "DROPDOWN_LIST",
+        "options": [
+          {
+            "value": "FPL-J30",
+            "poTerm": "common_option_program_familyPlanning_jovenes30",
+            "defaultName": "Jovenes 3.0"
+          },
+          {
+            "value": "FPL-Zika",
+            "poTerm": "common_option_program_familyPlanning_zika",
+            "defaultName": "Zika"
+          }
+        ],
+        "program:Jovenes": "true",
+        "program:Zika": "true"
+      },
+      {
+        "dataPointRef": "sessionDetails",
+        "poTerm": "ipc_issueEntry_q_sessionDetails",
+        "defaultName": "Session details:",
+        "controlType": "QUESTION_LABEL",
+        "mandatory": "false"
+      },
+      {
+        "dataPointRef": "contactSource",
+        "poTerm": "ipc_issueEntry_q_contactSource",
+        "defaultName": "Contact source",
+        "controlType": "DROPDOWN_LIST",
+        "options": [
+          {
+            "value": "POSTER",
+            "poTerm": "common_option_contactSource_poster",
+            "defaultName": "Poster / Presentation card"
+          },
+          {
+            "value": "FRIEND",
+            "poTerm": "common_option_contactSource_friend",
+            "defaultName": "Referred by a friend"
+          },
+          {
+            "value": "FB-FP-UsalaBien",
+            "poTerm": "common_option_contactSource_fbFpUsalaBien",
+            "defaultName": "Fanpage FB: Usala Bien"
+          },
+          {
+            "value": "FB-FP-MiZonaH",
+            "poTerm": "common_option_contactSource_fbFpMiZonaH",
+            "defaultName": "Fanpage FB: Mi Zona H"
+          },
+          {
+            "value": "FB-FP-ClubEnConexion",
+            "poTerm": "common_option_contactSource_fbFpClubEnConexion",
+            "defaultName": "Fanpage FB: Club en Conexion"
+          },
+          {
+            "value": "FB-FP-GeneracionCero",
+            "poTerm": "common_option_contactSource_fbFpGeneracionCero",
+            "defaultName": "Fanpage FB: Generacion Cero"
+          },
+          {
+            "value": "FB-Ad",
+            "poTerm": "common_option_contactSource_fbAd",
+            "defaultName": "Ad FB"
+          },
+          {
+            "value": "FB-Ad-WA",
+            "poTerm": "common_option_contactSource_fbAdToWhatsapp",
+            "defaultName": "Ad FB to WhatsApp"
+          },
+          {
+            "value": "IG-Ad",
+            "poTerm": "common_option_contactSource_igAd",
+            "defaultName": "Insta Ad"
+          },
+          {
+            "value": "FB-INF",
+            "poTerm": "common_option_contactSource_fbInfluencer",
+            "defaultName": "Fanpage FB: Refered via influencer"
+          },
+          {
+            "value": "REG",
+            "poTerm": "common_option_contactSource_regularReach",
+            "defaultName": "Regular reach"
+          }
+        ],
+        "program:Jovenes": "true",
+        "program:Zika": "true"
+      },
+      {
+        "dataPointRef": "contactSite",
+        "poTerm": "ipc_issueEntry_q_contactSite",
+        "defaultName": "Contact site",
+        "controlType": "DROPDOWN_LIST",
+        "options": [
+          {
+            "value": "FB-profile",
+            "poTerm": "common_option_contactSite_fbProfile",
+            "defaultName": "FB: Profile"
+          },
+          {
+            "value": "FB-FP-intern",
+            "poTerm": "common_option_contactSite_fbFpIntern",
+            "defaultName": "FB: Fanpage - Intern"
+          },
+          {
+            "value": "FB-FP-extern",
+            "poTerm": "common_option_contactSite_fbFpExtern",
+            "defaultName": "FB: Fanpage - Extern"
+          },
+          {
+            "value": "WA",
+            "poTerm": "common_option_contactSite_whatsapp",
+            "defaultName": "WhatsApp"
+          },
+          {
+            "value": "IG",
+            "poTerm": "common_option_contactSite_instagram",
+            "defaultName": "Instagram"
+          },
+          {
+            "value": "TT",
+            "poTerm": "common_option_contactSite_twitter",
+            "defaultName": "Twitter"
+          },
+          {
+            "value": "TD",
+            "poTerm": "common_option_contactSite_tinder",
+            "defaultName": "Tinder"
+          }
+        ],
+        "program:Jovenes": "true",
+        "program:Zika": "true"
+      },
+      {
+        "dataPointRef": "contactType",
+        "poTerm": "ipc_issueEntry_q_contactType",
+        "defaultName": "Contact type",
+        "controlType": "DROPDOWN_LIST",
+        "options": [
+          {
+            "value": "OUTR",
+            "poTerm": "common_option_contactType_outreach",
+            "defaultName": "Online outreach"
+          },
+          {
+            "value": "REQU",
+            "poTerm": "common_option_contactType_directRequest",
+            "defaultName": "Direct request online"
+          },
+          {
+            "value": "CONS",
+            "poTerm": "common_option_contactType_onlineConsultation",
+            "defaultName": "Online consultation"
+          }
+        ],
+        "program:Jovenes": "true",
+        "program:Zika": "true"
+      },
+      {
+        "dataPointRef": "clientDetails",
+        "poTerm": "ipc_issueEntry_q_clientDetails",
+        "defaultName": "Client details:",
+        "controlType": "QUESTION_LABEL",
+        "mandatory": "false"
+      },
+      {
+        "dataPointRef": "fullDetailsAvailable",
+        "poTerm": "ipc_issueEntry_q_fullDetailsAvailable",
+        "defaultName": "Full details available",
+        "defaultValue": "YES",
+        "controlType": "DROPDOWN_LIST",
+        "options": [
+          {
+            "value": "YES",
+            "poTerm": "common_btn_yes",
+            "defaultName": "Yes"
+          },
+          {
+            "value": "NO",
+            "poTerm": "common_btn_no",
+            "defaultName": "No"
+          }
+        ]
+      },
+      {
+        "dataPointRef": "firstName",
+        "poTerm": "ipc_issueEntry_q_firstName",
+        "defaultName": "First name",
+        "controlType": "SHORT_TEXT",
+        "queueDisplayPriority": "IMPORTANT",
+        "validationRegex": "^[ÑñA-Za-z][ÑñA-Za-z ]*[ÑñA-Za-z]$",
+        "validationPoTerm": "ipc_issueEntry_q_firstName_invalid"
+      },
+      {
+        "dataPointRef": "lastName",
+        "poTerm": "ipc_issueEntry_q_lastNameFirstTwoLetters",
+        "defaultName": "Last name",
+        "controlType": "SHORT_TEXT",
+        "queueDisplayPriority": "IMPORTANT",
+        "validationRegex": "^[ÑñA-Za-z][ÑñA-Za-z ]*[ÑñA-Za-z]$",
+        "validationPoTerm": "ipc_issueEntry_q_lastNameFirstTwoLetters_invalid"
+      },
+      {
+        "dataPointRef": "gender",
+        "poTerm": "ipc_issueEntry_q_gender",
+        "defaultName": "Gender",
+        "controlType": "DROPDOWN_LIST",
+        "options": [
+          {
+            "value": "F",
+            "poTerm": "common_option_gender_female",
+            "defaultName": "Female"
+          },
+          {
+            "value": "M",
+            "poTerm": "common_option_gender_male",
+            "defaultName": "Male"
+          },
+          {
+            "value": "U",
+            "poTerm": "common_option_gender_unknown",
+            "defaultName": "Unknown"
+          }
+        ]
+      },
+      {
+        "dataPointRef": "birthDate",
+        "poTerm": "ipc_issueEntry_q_birthDate",
+        "defaultName": "Birth date",
+        "controlType": "DATE"
+      },
+      {
+        "dataPointRef": "age",
+        "poTerm": "ipc_issueEntry_q_age",
+        "defaultName": "Age",
+        "controlType": "INT",
+        "validationRegex": "^(\\d{1,2})$",
+        "validationPoTerm": "ipc_issueEntry_q_age_invalid"
+      },
+      {
+        "dataPointRef": "motherFirstName",
+        "poTerm": "ipc_issueEntry_q_motherFirstNameFirstLetter",
+        "defaultName": "First name of mother",
+        "controlType": "SHORT_TEXT",
+        "validationRegex": "^[ÑñA-Za-z][ÑñA-Za-z]*$",
+        "validationPoTerm": "ipc_issueEntry_q_motherFirstNameFirstLetter_invalid"
+      },
+      {
+        "dataPointRef": "motherLastName",
+        "poTerm": "ipc_issueEntry_q_motherLastNameFirstLetter",
+        "defaultName": "Last name of mother",
+        "controlType": "SHORT_TEXT",
+        "validationRegex": "^[ÑñA-Za-z][ÑñA-Za-z]*$",
+        "validationPoTerm": "ipc_issueEntry_q_motherLastNameFirstLetter_invalid"
+      },
+      {
+        "dataPointRef": "educationLevel",
+        "poTerm": "ipc_issueEntry_q_educationLevel",
+        "defaultName": "Education level",
+        "controlType": "DROPDOWN_LIST",
+        "mandatory": "false",
+        "options": [
+          {
+            "value": "None",
+            "poTerm": "common_option_educationLevel_none",
+            "defaultName": "None"
+          },
+          {
+            "value": "Primary",
+            "poTerm": "common_option_educationLevel_primary",
+            "defaultName": "Primary"
+          },
+          {
+            "value": "Secondary",
+            "poTerm": "common_option_educationLevel_secondary",
+            "defaultName": "Secondary"
+          },
+          {
+            "value": "Diversified",
+            "poTerm": "common_option_educationLevel_diversified",
+            "defaultName": "Diversified"
+          },
+          {
+            "value": "Technical",
+            "poTerm": "common_option_educationLevel_technical",
+            "defaultName": "Technical"
+          },
+          {
+            "value": "University",
+            "poTerm": "common_option_educationLevel_university",
+            "defaultName": "University"
+          },
+          {
+            "value": "Master",
+            "poTerm": "common_option_educationLevel_master",
+            "defaultName": "Master"
+          },
+          {
+            "value": "PostGraduate",
+            "poTerm": "common_option_educationLevel_postGraduate",
+            "defaultName": "Post-graduate"
+          }
+        ]
+      },
+      {
+        "dataPointRef": "healthyBehaviorPromoted_zika",
+        "poTerm": "ipc_issueEntry_q_healthyBehaviorPromoted",
+        "defaultName": "Healthy behavior promoted",
+        "controlType": "DROPDOWN_LIST",
+        "options": [
+          {
+            "value": "B-Z-CON",
+            "poTerm": "common_option_healthyBehaviorPromoted_bzcon",
+            "defaultName": "Zika and condom use"
+          },
+          {
+            "value": "B-Z-FPL",
+            "poTerm": "common_option_healthyBehaviorPromoted_bzfpl",
+            "defaultName": "Zika and family planning methods"
+          },
+          {
+            "value": "Z-PRO",
+            "poTerm": "common_option_healthyBehaviorPromoted_zpro",
+            "defaultName": "Zika, general protection methods"
+          },
+          {
+            "value": "Z-RSK",
+            "poTerm": "common_option_healthyBehaviorPromoted_zrsk",
+            "defaultName": "Zika, risk perception"
+          },
+          {
+            "value": "B-COMP-FU",
+            "poTerm": "common_option_healthyBehaviorPromoted_bcompfu",
+            "defaultName": "Comprehensive follow-up"
+          }
+        ]
+      },
+      {
+        "dataPointRef": "healthyBehaviorPromoted_j30",
+        "poTerm": "ipc_issueEntry_q_healthyBehaviorPromoted",
+        "defaultName": "Healthy behavior promoted",
+        "controlType": "DROPDOWN_LIST",
+        "options": [
+          {
+            "value": "B-Z-CON",
+            "poTerm": "common_option_healthyBehaviorPromoted_bzcon",
+            "defaultName": "Zika and condom use"
+          },
+          {
+            "value": "B-Z-FPL",
+            "poTerm": "common_option_healthyBehaviorPromoted_bzfpl",
+            "defaultName": "Zika and family planning methods"
+          },
+          {
+            "value": "J-FPL",
+            "poTerm": "common_option_healthyBehaviorPromoted_jfpl",
+            "defaultName": "Contraceptive methods use"
+          },
+          {
+            "value": "J-SPE",
+            "poTerm": "common_option_healthyBehaviorPromoted_jspe",
+            "defaultName": "Seeking specialized care"
+          },
+          {
+            "value": "J-CON",
+            "poTerm": "common_option_healthyBehaviorPromoted_jcon",
+            "defaultName": "Correct and consistent use of condom"
+          },
+          {
+            "value": "J-SSR",
+            "poTerm": "common_option_healthyBehaviorPromoted_jssr",
+            "defaultName": "General medical consultation"
+          },
+          {
+            "value": "J-VIO",
+            "poTerm": "common_option_healthyBehaviorPromoted_jvio",
+            "defaultName": "Victim of violence seeking support"
+          },
+          {
+            "value": "B-COMP-FU",
+            "poTerm": "common_option_healthyBehaviorPromoted_bcompfu",
+            "defaultName": "Comprehensive follow-up"
+          }
+        ]
+      },
+      {
+        "dataPointRef": "voucherDetails",
+        "poTerm": "ipc_issueEntry_q_voucherDetails",
+        "defaultName": "Voucher details:",
+        "controlType": "QUESTION_LABEL",
+        "mandatory": "false"
+      },
+      {
+        "dataPointRef": "generateVoucher",
+        "poTerm": "ipc_issueEntry_q_isClientReferred",
+        "defaultName": "Would you like to issue a voucher?",
+        "controlType": "DROPDOWN_LIST",
+        "options": [
+          {
+            "value": "YES",
+            "poTerm": "common_btn_yes",
+            "defaultName": "Yes"
+          },
+          {
+            "value": "NO",
+            "poTerm": "common_btn_no",
+            "defaultName": "No"
+          }
+        ]
+      },
+      {
+        "dataPointRef": "serviceDesired_fplcoun",
+        "poTerm": "common_option_serviceDesired_fplcoun",
+        "defaultName": "Contraceptive methods counselling",
+        "controlType": "RADIO_GROUP_HORIZONTAL",
+        "mandatory": "false",
+        "options": [
+          {
+            "value": "YES",
+            "poTerm": "ipc_issueEntry_q_blank",
+            "defaultName": "YES"
+          }
+        ],
+        "voucherCodeSuffix": {
+          "suffix": "MAC",
+          "valueCondition": "YES"
+        }
+      },
+      {
+        "dataPointRef": "serviceDesired_medcons",
+        "poTerm": "common_option_serviceDesired_medcons",
+        "defaultName": "Medical consultation",
+        "controlType": "RADIO_GROUP_HORIZONTAL",
+        "mandatory": "false",
+        "options": [
+          {
+            "value": "YES",
+            "poTerm": "ipc_issueEntry_q_blank",
+            "defaultName": "YES"
+          }
+        ],
+        "voucherCodeSuffix": {
+          "suffix": "SSR",
+          "valueCondition": "YES"
+        }
+
+      },
+      {
+        "dataPointRef": "serviceDesired_hivtest",
+        "poTerm": "common_option_serviceDesired_hivtest",
+        "defaultName": "HIV testing",
+        "controlType": "RADIO_GROUP_HORIZONTAL",
+        "mandatory": "false",
+        "options": [
+          {
+            "value": "YES",
+            "poTerm": "ipc_issueEntry_q_blank",
+            "defaultName": "YES"
+          }
+        ],
+        "voucherCodeSuffix": {
+          "suffix": "PVC",
+          "valueCondition": "YES"
+        }
+      },
+      {
+        "dataPointRef": "serviceDesired_cito",
+        "poTerm": "common_option_serviceDesired_cito",
+        "defaultName": "Citology",
+        "controlType": "RADIO_GROUP_HORIZONTAL",
+        "mandatory": "false",
+        "options": [
+          {
+            "value": "YES",
+            "poTerm": "ipc_issueEntry_q_blank",
+            "defaultName": "YES"
+          }
+        ],
+        "voucherCodeSuffix": {
+          "suffix": "CIT",
+          "valueCondition": "YES"
+        }
+      },
+      {
+        "dataPointRef": "serviceDesired_osti",
+        "poTerm": "common_option_serviceDesired_osti",
+        "defaultName": "Other STI",
+        "controlType": "RADIO_GROUP_HORIZONTAL",
+        "mandatory": "false",
+        "options": [
+          {
+            "value": "YES",
+            "poTerm": "ipc_issueEntry_q_blank",
+            "defaultName": "YES"
+          }
+        ],
+        "voucherCodeSuffix": {
+          "suffix": "ITS",
+          "valueCondition": "YES"
+        }
+      },
+      {
+        "dataPointRef": "healthFacility",
+        "poTerm": "ipc_issueEntry_q_healthFacility",
+        "defaultName": "Health facility",
+        "controlType": "AUTOCOMPLETE",
+        "options": [
+          {
+            "value": "0801-SSIAA-VC",
+            "poTerm": "SSIAA Central Vicente Caceres (0801-SSIAA-VC)",
+            "defaultName": "SSIAA Central Vicente Caceres (0801-SSIAA-VC)"
+          },
+          {
+            "value": "0801-CM-RS",
+            "poTerm": "Clinicas Medica Red Segura (0801-CM-RS)",
+            "defaultName": "Clinicas Medica Red Segura (0801-CM-RS)"
+          },
+          {
+            "value": "0801-CS-AS",
+            "poTerm": "Centro de Salud Alonso Suazo (0801-CS-AS)",
+            "defaultName": "Centro de Salud Alonso Suazo (0801-CS-AS)"
+          },
+          {
+            "value": "0801-CS-SM",
+            "poTerm": "Centro de Salud San Miguel (0801-CS-SM)",
+            "defaultName": "Centro de Salud San Miguel (0801-CS-SM)"
+          },
+          {
+            "value": "0801-CS-CA",
+            "poTerm": "Centro de Salud Carrizal (0801-CS-CA)",
+            "defaultName": "Centro de Salud Carrizal (0801-CS-CA)"
+          },
+          {
+            "value": "0801-CS-FC",
+            "poTerm": "Centro de Salud Flor del Campo (0801-CS-FC)",
+            "defaultName": "Centro de Salud Flor del Campo (0801-CS-FC)"
+          },
+          {
+            "value": "0501-CS-MP",
+            "poTerm": "Miguel Paz Barahona(Centra de Salud) (0501-CS-MP)",
+            "defaultName": "Miguel Paz Barahona(Centra de Salud) (0501-CS-MP)"
+          },
+          {
+            "value": "0501-CS-LP",
+            "poTerm": "Centro de Salud Las Palmas (0501-CS-LP)",
+            "defaultName": "Centro de Salud Las Palmas (0501-CS-LP)"
+          },
+          {
+            "value": "0501-HOSP-MC",
+            "poTerm": "Hospital Mario Catarino Rivas (0501-HOSP-MC)",
+            "defaultName": "Hospital Mario Catarino Rivas (0501-HOSP-MC)"
+          },
+          {
+            "value": "0501-SSIAA-JT",
+            "poTerm": "SSIAA Jose Trinidad Reyes (0501-SSIAA-JT)",
+            "defaultName": "SSIAA Jose Trinidad Reyes (0501-SSIAA-JT)"
+          },
+          {
+            "value": "0502-CMI-CH",
+            "poTerm": "Clinica Materno Infantil de Choloma (0502-CMI-CH)",
+            "defaultName": "Clinica Materno Infantil de Choloma (0502-CMI-CH)"
+          },
+          {
+            "value": "0502-CS-PI",
+            "poTerm": "Centro de Salud Pascual Izaguirre (0502-CS-PI)",
+            "defaultName": "Centro de Salud Pascual Izaguirre (0502-CS-PI)"
+          },
+          {
+            "value": "0502-SSIAA-MP",
+            "poTerm": "SSIAA Manuel Pagan Losano (0502-SSIAA-MP)",
+            "defaultName": "SSIAA Manuel Pagan Losano (0502-SSIAA-MP)"
+          },
+          {
+            "value": "0101-SSIAA-MB",
+            "poTerm": "SSIAA Manuel Banilla (0101-SSIAA-MB)",
+            "defaultName": "SSIAA Manuel Banilla (0101-SSIAA-MB)"
+          }
+        ]
+      },
+      {
+        "dataPointRef": "phoneOwnership",
+        "poTerm": "ipc_issueEntry_q_ownershipOfPhone",
+        "defaultName": "Phone ownership",
+        "controlType": "DROPDOWN_LIST",
+        "options": [
+          {
+            "value": "NO",
+            "poTerm": "common_option_ownershipOfPhone_noMobile",
+            "defaultName": "No Number"
+          },
+          {
+            "value": "HER",
+            "poTerm": "common_option_ownershipOfPhone_herNumber",
+            "defaultName": "Her Number"
+          },
+          {
+            "value": "PAR",
+            "poTerm": "common_option_ownershipOfPhone_husbandPartner",
+            "defaultName": "Husband/Partner"
+          },
+          {
+            "value": "SHA",
+            "poTerm": "common_option_ownershipOfPhone_shared",
+            "defaultName": "Shared"
+          }
+        ]
+      },
+      {
+        "dataPointRef": "phoneNumber",
+        "poTerm": "ipc_issueEntry_q_phoneNumber",
+        "defaultName": "Phone number",
+        "controlType": "PHONE_NUMBER",
+        "validationRegex": "^(\\+[^504]\\d*|00[^504]\\d*|\\d{8}|\\+504\\d{8}|00504\\d{8})$",
+        "validationPoTerm": "ipc_issueEntry_q_ownershipOfPhone_invalid",
+        "samples": [
+          {
+            "value": "undefined",
+            "provider": "undefined"
+          }
+        ],
+        "format": {
+          "accepted": [
+            {
+              "starts": "",
+              "length": "8",
+              "comment": "national"
+            },
+            {
+              "starts": "+",
+              "comment": "international"
+            },
+            {
+              "starts": "00",
+              "comment": "international"
+            }
+          ],
+          "details": {
+            "trunkPrefix": "",
+            "dialingCode": "+504"
+          }
+        }
+      },
+      {
+        "dataPointRef": "phoneContactConsent",
+        "poTerm": "ipc_issueEntry_q_phoneContactConsent_service",
+        "defaultName": "Consent to service-related calls/texts",
+        "controlType": "DROPDOWN_LIST",
+        "defaultValue": "YESP",
+        "options": [
+          {
+            "value": "YESP",
+            "poTerm": "common_option_furtherInformationConsent_yes",
+            "defaultName": "Yes"
+          },
+          {
+            "value": "NO",
+            "poTerm": "common_option_furtherInformationConsent_no",
+            "defaultName": "No"
+          }
+        ]
+      },
+      {
+        "dataPointRef": "phoneContactConsent_feedback",
+        "poTerm": "ipc_issueEntry_q_phoneContactConsent_feedback",
+        "defaultName": "Consent to feedback calls/texts",
+        "controlType": "DROPDOWN_LIST",
+        "defaultValue": "YESP",
+        "options": [
+          {
+            "value": "YESP",
+            "poTerm": "common_option_furtherInformationConsent_yes",
+            "defaultName": "Yes"
+          },
+          {
+            "value": "NO",
+            "poTerm": "common_option_furtherInformationConsent_no",
+            "defaultName": "No"
+          }
+        ]
+      }
+    ],
+    "rulesSpecs": [
+      {
+        "ruleRef": "in:program",
+        "conditions": [
+          {
+            "left": {
+              "value": "program",
+              "type": "dataPointRef"
+            },
+            "operator": "==",
+            "right": {
+              "value": "FPL-Zika",
+              "type": "value"
+            }
+          }
+        ],
+        "actions": [
+          {
+            "dataPointRef": "healthyBehaviorPromoted_zika",
+            "do": "SHOW"
+          }
+        ]
+      },
+      {
+        "ruleRef": "in:program",
+        "conditions": [
+          {
+            "left": {
+              "value": "program",
+              "type": "dataPointRef"
+            },
+            "operator": "==",
+            "right": {
+              "value": "FPL-J30",
+              "type": "value"
+            }
+          }
+        ],
+        "actions": [
+          {
+            "dataPointRef": "healthyBehaviorPromoted_j30",
+            "do": "SHOW"
+          }
+        ]
+      },
+      {
+        "ruleRef": "in:fullDetailsAvailable",
+        "conditions": [
+          {
+            "left": {
+              "value": "fullDetailsAvailable",
+              "type": "dataPointRef"
+            },
+            "operator": "==",
+            "right": {
+              "value": "YES",
+              "type": "value"
+            }
+          }
+        ],
+        "actions": [
+          {
+            "dataPointRef": "firstName",
+            "do": "SHOW"
+          },
+          {
+            "dataPointRef": "lastName",
+            "do": "SHOW"
+          },
+          {
+            "dataPointRef": "birthDate",
+            "do": "SHOW"
+          },
+          {
+            "dataPointRef": "motherFirstName",
+            "do": "SHOW"
+          },
+          {
+            "dataPointRef": "motherLastName",
+            "do": "SHOW"
+          }
+        ]
+      },
+      {
+        "ruleRef": "in:fullDetailsAvailable",
+        "conditions": [
+          {
+            "left": {
+              "value": "fullDetailsAvailable",
+              "type": "dataPointRef"
+            },
+            "operator": "==",
+            "right": {
+              "value": "NO",
+              "type": "value"
+            }
+          }
+        ],
+        "actions": [
+          {
+            "dataPointRef": "age",
+            "do": "SHOW"
+          }
+        ]
+      },
+      {
+        "ruleRef": "in:generateVoucher",
+        "conditions": [
+          {
+            "left": {
+              "value": "generateVoucher",
+              "type": "dataPointRef"
+            },
+            "operator": "==",
+            "right": {
+              "value": "YES",
+              "type": "value"
+            }
+          }
+        ],
+        "actions": [
+          {
+            "dataPointRef": "serviceDesired_fplcoun",
+            "do": "SHOW"
+          },
+          {
+            "dataPointRef": "serviceDesired_medcons",
+            "do": "SHOW"
+          },
+          {
+            "dataPointRef": "serviceDesired_hivtest",
+            "do": "SHOW"
+          },
+          {
+            "dataPointRef": "serviceDesired_cito",
+            "do": "SHOW"
+          },
+          {
+            "dataPointRef": "serviceDesired_osti",
+            "do": "SHOW"
+          },
+          {
+            "dataPointRef": "healthFacility",
+            "do": "SHOW"
+          },
+          {
+            "dataPointRef": "phoneOwnership",
+            "do": "SHOW"
+          }
+        ]
+      },
+      {
+        "ruleRef": "in:phoneOwnership",
+        "conditions": [
+          {
+            "left": {
+              "value": "phoneOwnership",
+              "type": "dataPointRef"
+            },
+            "operator": "==",
+            "right": {
+              "value": "HER",
+              "type": "value"
+            }
+          },
+          {
+            "left": {
+              "value": "phoneOwnership",
+              "type": "dataPointRef"
+            },
+            "operator": "==",
+            "right": {
+              "value": "PAR",
+              "type": "value"
+            }
+          },
+          {
+            "left": {
+              "value": "phoneOwnership",
+              "type": "dataPointRef"
+            },
+            "operator": "==",
+            "right": {
+              "value": "SHA",
+              "type": "value"
+            }
+          }
+        ],
+        "actions": [
+          {
+            "dataPointRef": "phoneNumber",
+            "do": "SHOW"
+          },
+          {
+            "dataPointRef": "phoneContactConsent",
+            "do": "SHOW"
+          },
+          {
+            "dataPointRef": "phoneContactConsent_feedback",
+            "do": "SHOW"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2441                
* **Related pull-requests:** 

###   :gear: branches 
**app**: 
       Origin: maintenance/voucher_code_suffix Target: v1.4_connect
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   

### :tophat: What is the goal?

Customize voucher codes in the format of: 
[voucher_code] + ‘_’ + [service_code1] (+ ‘_’ + [service_codeX] ...) 

### :memo: How is it being implemented?

To every question with suffix should have the next structure:
```
{
    "dataPointRef": "serviceDesired_fplcoun",
     ...
     "voucherCodeSuffix": {
          "suffix": "MAC",
          "valueCondition": "YES"
      }
}
```
- I have created voucher Code Suffix in network models, to update conversion to domain
- I have modified existed tests
- I have created columns for suffix in QuestionDB and I have updated conversion to db models and tests
- I have created question migration
- I have created new field visible_voucher_uid on survey db and domain models 
- I have created survey migration
- I have created VoucherSuffixDomainService to calculate suffix and I have created tests
- The visible vocuher uid is shown on alert after send survey and in survey list
- The push send voucheruid without suffix to server

### :boom: How can it be tested?

Add suffix to questions in server configuration according to [requirements document](https://docs.google.com/document/d/1-bEBsmvefQ0plY7yV5t8JGpB6Qn9qsnsGYtBrqdeU7M/edit?usp=sharing) and login with user HN_TEST_IPC

**UseCase 1**: create a new survey with voucher uid and select Contraceptive methods counselling the visible voucher uid should be xxxxxx_MAC

**UseCase 2**: create a new survey with voucher uid and select Medical consultation the visible voucher uid should be xxxxxx_SSR

**UseCase 3**: create a new survey with voucher uid and select HIV testing the visible voucher uid should be xxxxxx_PVC

**UseCase 4**: create a new survey with voucher uid and select Citology the visible voucher uid should be xxxxxx_CIT

**UseCase 5**: create a new survey with voucher uid and select Other STI the visible voucher uid should be xxxxxx_ITS

**UseCase 6**: create a new survey with voucher uid and select Contraceptive methods counselling, Medical consultation, HIV testing, Citology and Other STI the visible voucher uid should be xxxxxx_MAC_SSR_PVC_CIT_ITS

Last, change variant to EreferralsStaging and run unit and instrumentation tests.
Remember change variant againto EreferralsDebug

### :floppy_disk: Requires DB migration?

- [ ] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [x] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
