### PR TITLE
Add extra keys mock response

### DIFF
--- a/app/src/testEreferrals/java/org/eyeseetea/malariacare/data/sync/exporter/eReferralsAPIClientShould.java
+++ b/app/src/testEreferrals/java/org/eyeseetea/malariacare/data/sync/exporter/eReferralsAPIClientShould.java
@@ -30,6 +30,7 @@ public class eReferralsAPIClientShould {
     private static final String PUSH_RESPONSE_OK_EXTRA_KEYS = "push_response_ok_extra_keys.json";
     private static final String API_AVAILABLE_OK = "api_available_ok.json";
     private static final String API_AVAILABLE_NO_OK = "api_available_no_ok.json";
+    private static final String API_AVAILABLE_OK_EXTRA_KEYS = "api_available_ok_extra_keys.json";
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -72,7 +73,7 @@ public class eReferralsAPIClientShould {
     @Test
     public void return_success_result_when_api_response_contains_extra_keys()
             throws IOException {
-        mockWebServerRule.getMockServer().enqueueMockResponseFileName(200, API_AVAILABLE_OK);
+        mockWebServerRule.getMockServer().enqueueMockResponseFileName(200, API_AVAILABLE_OK_EXTRA_KEYS);
         mockWebServerRule.getMockServer().enqueueMockResponseFileName(200, PUSH_RESPONSE_OK_EXTRA_KEYS);
         eReferralsAPIClient eReferralsAPIClient = new eReferralsAPIClient(
                 mockWebServerRule.getMockServer().getBaseEndpoint());

--- a/app/src/testEreferrals/resources/api_available_ok_extra_keys.json
+++ b/app/src/testEreferrals/resources/api_available_ok_extra_keys.json
@@ -1,0 +1,5 @@
+{
+  "available": true,
+  "msg": "Test message",
+  "extraKey": "extra value"
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2445                 
* **Related pull-requests:** 

###   :gear: branches 
**app**: 
       Origin: maintenance/add_api_available_endpoint_extra_keys_verification Target: v1.4_connect
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   

### :tophat: What is the goal?

Modify a existed test to validate eReferralsApiClient does not fail when available api  response contains extra keys 

### :memo: How is it being implemented?

- I have created a new fake response api_available_ok_extra_keys.json file
- I have modified return_success_result_when_api_response_contains_extra_keys test method of eReferralsAPIClientShould to enqueue api_available_ok_extra_keys.json mock response

### :boom: How can it be tested?

Change build variant to ereferralsStaging

**UseCase 1**: execute return_success_result_when_api_response_contains_extra_keys test

**Remember change build variant to erefferralsDebug again**

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
