### PR TITLE
Avoid jump to disabled field

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/CommonQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/CommonQuestionView.java
@@ -3,6 +3,7 @@ package org.eyeseetea.malariacare.views.question;
 import static android.content.Context.INPUT_METHOD_SERVICE;
 
 import android.content.Context;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
@@ -103,7 +104,7 @@ public class CommonQuestionView extends LinearLayout {
     }
 
     public void focusNextQuestion() {
-        if (jumpingNextQuestionActive){
+        if (jumpingNextQuestionActive) {
             View nextView = getNextView();
             if (nextView == null) {
                 return;
@@ -114,16 +115,22 @@ public class CommonQuestionView extends LinearLayout {
                 nextView = mLayout.getChildAt(
                         mLayout.indexOfChild(nextView) + 1);
             }
+
             if (nextView.getVisibility() != View.GONE) {
                 IQuestionView nextQuestionView =
                         (IQuestionView) ((TableRow) nextView).getChildAt(
                                 0);
 
-                if (thisAndNextQuestionAreAKeyboardQuestionView(nextQuestionView)) {
-                    // use standard Android requestFocus only between keyboard questions
-                    nextView.requestFocus();
+                if (nextQuestionView.isEnabled()) {
+                    if (thisAndNextQuestionAreAKeyboardQuestionView(nextQuestionView)) {
+                        // use standard Android requestFocus only between keyboard questions
+                        nextView.requestFocus();
+                    } else {
+                        ((IMultiQuestionView) nextQuestionView).requestAnswerFocus();
+                    }
                 } else {
-                    ((IMultiQuestionView) nextQuestionView).requestAnswerFocus();
+                    Log.d(this.getClass().getSimpleName(),
+                            "No jump because the nextQuestionView is disabled");
                 }
             }
         }
@@ -147,20 +154,22 @@ public class CommonQuestionView extends LinearLayout {
         return (IQuestionView) ((ViewGroup) nextView).getChildAt(0);
     }
 
-    public void setQuestion(Question question){
+    public void setQuestion(Question question) {
         this.question = question;
     }
 
     public boolean validateQuestionRegExp(TextView view) {
         try {
-            if(question == null || question.getRegExp()==null || question.getRegExp().isEmpty()) {
+            if (question == null || question.getRegExp() == null
+                    || question.getRegExp().isEmpty()) {
                 return true;
             }
             question.match(view.getText().toString());
             return true;
         } catch (RegExpValidationException e) {
             e.printStackTrace();
-            String errorMessage = Utils.getInternationalizedString(question.getRegExpError(), getContext());
+            String errorMessage = Utils.getInternationalizedString(question.getRegExpError(),
+                    getContext());
             Validation.getInstance().addinvalidInput(view,
                     errorMessage);
             view.setError(errorMessage);

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/IQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/IQuestionView.java
@@ -3,6 +3,8 @@ package org.eyeseetea.malariacare.views.question;
 import org.eyeseetea.malariacare.data.database.model.ValueDB;
 
 public interface IQuestionView {
+    boolean isEnabled();
+
     void setEnabled(boolean enabled);
 
     void setHelpText(String helpText);

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/DatePickerQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/DatePickerQuestionView.java
@@ -105,6 +105,11 @@ public class DatePickerQuestionView extends CommonQuestionView implements IQuest
     }
 
     @Override
+    public boolean isEnabled(){
+        return this.enabled;
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         super.setEnabled(enabled);
         this.enabled = enabled;

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/DropdownMultiQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/DropdownMultiQuestionView.java
@@ -70,6 +70,11 @@ public class DropdownMultiQuestionView extends AOptionQuestionView implements IQ
     }
 
     @Override
+    public boolean isEnabled(){
+        return spinnerOptions.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         spinnerOptions.setEnabled(enabled);
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/DropdownWithFilterMultiQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/DropdownWithFilterMultiQuestionView.java
@@ -149,6 +149,11 @@ public class DropdownWithFilterMultiQuestionView extends AOptionQuestionView imp
     }
 
     @Override
+    public boolean isEnabled(){
+        return spinnerAsButton.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         spinnerAsButton.setEnabled(enabled);
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/LabelMultiQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/LabelMultiQuestionView.java
@@ -41,6 +41,11 @@ public class LabelMultiQuestionView extends CommonQuestionView implements IQuest
     }
 
     @Override
+    public boolean isEnabled(){
+        return true;
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
     }
 

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/NumberMultiQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/NumberMultiQuestionView.java
@@ -36,6 +36,11 @@ public class NumberMultiQuestionView extends AKeyboardQuestionView implements IQ
     }
 
     @Override
+    public boolean isEnabled(){
+        return answer.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         answer.setEnabled(enabled);
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/PhoneMultiQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/PhoneMultiQuestionView.java
@@ -32,6 +32,11 @@ public class PhoneMultiQuestionView extends AKeyboardQuestionView implements IQu
     }
 
     @Override
+    public boolean isEnabled(){
+        return answer.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         answer.setEnabled(enabled);
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/PositiveNumberMultiQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/PositiveNumberMultiQuestionView.java
@@ -39,6 +39,11 @@ public class PositiveNumberMultiQuestionView extends AKeyboardQuestionView imple
     }
 
     @Override
+    public boolean isEnabled(){
+        return answer.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         answer.setEnabled(enabled);
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/PositiveOrZeroNumberMultiQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/PositiveOrZeroNumberMultiQuestionView.java
@@ -39,6 +39,11 @@ public class PositiveOrZeroNumberMultiQuestionView extends AKeyboardQuestionView
     }
 
     @Override
+    public boolean isEnabled(){
+        return answer.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         answer.setEnabled(enabled);
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/PregnantMonthNumberMultiQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/PregnantMonthNumberMultiQuestionView.java
@@ -40,6 +40,11 @@ public class PregnantMonthNumberMultiQuestionView extends AKeyboardQuestionView 
     }
 
     @Override
+    public boolean isEnabled(){
+        return answer.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         answer.setEnabled(enabled);
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/RadioButtonMultiQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/RadioButtonMultiQuestionView.java
@@ -82,6 +82,11 @@ public class RadioButtonMultiQuestionView extends AOptionQuestionView implements
     }
 
     @Override
+    public boolean isEnabled(){
+        return radioGroup.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         radioGroup.setEnabled(enabled);
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/SwitchMultiQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/SwitchMultiQuestionView.java
@@ -63,6 +63,11 @@ public class SwitchMultiQuestionView extends AOptionQuestionView implements IQue
     }
 
     @Override
+    public boolean isEnabled(){
+        return switchView.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         switchView.setEnabled(enabled);
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/TextMultiQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/TextMultiQuestionView.java
@@ -37,6 +37,11 @@ public class TextMultiQuestionView extends AKeyboardQuestionView implements IQue
     }
 
     @Override
+    public boolean isEnabled(){
+        return answer.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         answer.setEnabled(enabled);
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/YearSelectorQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/multiquestion/YearSelectorQuestionView.java
@@ -135,6 +135,11 @@ public class YearSelectorQuestionView extends CommonQuestionView implements IQue
     }
 
     @Override
+    public boolean isEnabled(){
+        return super.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         super.setEnabled(enabled);
         this.enabled = enabled;

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/DatePickerSingleQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/DatePickerSingleQuestionView.java
@@ -86,6 +86,11 @@ public class DatePickerSingleQuestionView extends AKeyboardSingleQuestionView im
     }
 
     @Override
+    public boolean isEnabled(){
+        return this.enabled;
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         super.setEnabled(enabled);
         this.enabled = enabled;

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/ImageOptionSingleQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/ImageOptionSingleQuestionView.java
@@ -66,6 +66,11 @@ public class ImageOptionSingleQuestionView extends AOptionQuestionView implement
     }
 
     @Override
+    public boolean isEnabled(){
+        return super.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         super.setEnabled(enabled);
 

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/ImageRadioButtonSingleQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/ImageRadioButtonSingleQuestionView.java
@@ -49,6 +49,11 @@ public class ImageRadioButtonSingleQuestionView extends AOptionQuestionView impl
     }
 
     @Override
+    public boolean isEnabled(){
+        return answersContainer.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         super.setEnabled(enabled);
         answersContainer.setEnabled(enabled);

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/MonthNumberSingleQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/MonthNumberSingleQuestionView.java
@@ -42,6 +42,11 @@ public class MonthNumberSingleQuestionView extends AKeyboardSingleQuestionView i
     }
 
     @Override
+    public boolean isEnabled(){
+        return numberPicker.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         numberPicker.setEnabled(enabled);
         sendButton.setEnabled(enabled);

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/NumberSingleQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/NumberSingleQuestionView.java
@@ -38,6 +38,11 @@ public class NumberSingleQuestionView extends AKeyboardSingleQuestionView implem
     }
 
     @Override
+    public boolean isEnabled(){
+        return numberPicker.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         numberPicker.setEnabled(enabled);
         sendButton.setEnabled(enabled);

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/PhoneSingleQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/PhoneSingleQuestionView.java
@@ -33,6 +33,11 @@ public class PhoneSingleQuestionView extends AKeyboardSingleQuestionView impleme
     }
 
     @Override
+    public boolean isEnabled(){
+        return mCustomEditText.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         mCustomEditText.setEnabled(enabled);
         sendButton.setEnabled(enabled);

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/PositiveNumberSingleQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/PositiveNumberSingleQuestionView.java
@@ -39,6 +39,11 @@ public class PositiveNumberSingleQuestionView extends AKeyboardSingleQuestionVie
     }
 
     @Override
+    public boolean isEnabled(){
+        return numberPicker.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         numberPicker.setEnabled(enabled);
         sendButton.setEnabled(enabled);

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/PositiveOrZeroNumberSingleQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/PositiveOrZeroNumberSingleQuestionView.java
@@ -43,6 +43,11 @@ public class PositiveOrZeroNumberSingleQuestionView  extends AKeyboardSingleQues
     }
 
     @Override
+    public boolean isEnabled(){
+        return numberPicker.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         numberPicker.setEnabled(enabled);
         sendButton.setEnabled(enabled);

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/PregnantMonthNumberSingleQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/PregnantMonthNumberSingleQuestionView.java
@@ -41,6 +41,11 @@ public class PregnantMonthNumberSingleQuestionView extends AKeyboardSingleQuesti
     }
 
     @Override
+    public boolean isEnabled(){
+        return numberPicker.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         numberPicker.setEnabled(enabled);
         sendButton.setEnabled(enabled);

--- a/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/TextSingleQuestionView.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/views/question/singlequestion/TextSingleQuestionView.java
@@ -42,6 +42,11 @@ public class TextSingleQuestionView extends AKeyboardSingleQuestionView implemen
     }
 
     @Override
+    public boolean isEnabled(){
+        return mEditText.isEnabled();
+    }
+
+    @Override
     public void setEnabled(boolean enabled) {
         mEditText.setEnabled(enabled);
         sendButton.setEnabled(enabled);


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2445                 
* **Related pull-requests:** 

###   :gear: branches 
**app**: 
       Origin: maintenance/jump_error_if_next_is_disabled Target: v1.4_connect
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   

### :tophat: What is the goal?

We should not jump to disabled fields in the survey

### :memo: How is it being implemented?

- I have added isEnabled getter to IQuestionView interface
- I have implemented isEnabled getter in all custom views
- I have modified jumping logic to avoid jump if the next field is disabled

### :boom: How can it be tested?

**UseCase 1**: Login with TZ_TEST_IPC, create a new survey and select Activity = Mjanaja then jumping should work but to found the last disabled field, the jump should be not realized.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
