### PR TITLE
Verify null networkInfo

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/net/ConnectivityManager.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/net/ConnectivityManager.java
@@ -5,13 +5,14 @@ import android.net.NetworkInfo;
 
 import org.eyeseetea.malariacare.domain.boundary.IConnectivityManager;
 
-public class ConnectivityManager implements IConnectivityManager{
+public class ConnectivityManager implements IConnectivityManager {
 
     private Context mContext;
 
     public ConnectivityManager(Context context) {
         this.mContext = context;
     }
+
     /**
      * Checks whether the device currently has a network connection.
      *
@@ -27,18 +28,24 @@ public class ConnectivityManager implements IConnectivityManager{
 
     @Override
     public ConnectivityType getConnectivityType() {
-        android.net.ConnectivityManager connMgr =
-                (android.net.ConnectivityManager) mContext.getSystemService(
-                                Context.CONNECTIVITY_SERVICE);
+        try {
+            android.net.ConnectivityManager connMgr =
+                    (android.net.ConnectivityManager) mContext.getSystemService(
+                            Context.CONNECTIVITY_SERVICE);
 
-        NetworkInfo networkInfo = connMgr.getNetworkInfo(android.net.ConnectivityManager.TYPE_WIFI);
-        if (networkInfo.isConnected()) {
-            return ConnectivityType.WIFI;
+            NetworkInfo networkInfo = connMgr.getNetworkInfo(
+                    android.net.ConnectivityManager.TYPE_WIFI);
+            if (networkInfo != null && networkInfo.isConnected()) {
+                return ConnectivityType.WIFI;
+            }
+            networkInfo = connMgr.getNetworkInfo(android.net.ConnectivityManager.TYPE_MOBILE);
+            if (networkInfo != null && networkInfo.isConnected()) {
+                return ConnectivityType.MOBILE;
+            }
+
+            return ConnectivityType.NONE;
+        } catch (Exception e) {
+            return ConnectivityType.NONE;
         }
-        networkInfo = connMgr.getNetworkInfo(android.net.ConnectivityManager.TYPE_MOBILE);
-        if (networkInfo.isConnected()) {
-            return ConnectivityType.MOBILE;
-        }
-        return ConnectivityType.NONE;
     }
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2444                   
* **Related pull-requests:** 

###   :gear: branches 
**app**: 
       Origin: maintenance/fix_offline_soft_login_bug_in_tablet_without_sim_card Target: v1.4_connect
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   

### :tophat: What is the goal?

A customer has reported  bug to realize soft login in offline mode.

### :memo: How is it being implemented?

The problem is retrieving networkInfo on devices with sim card because connMgr.getNetworkInfo(android.net.ConnectivityManager.TYPE_MOBILE) returns null in this scenario.

I have added null condition for TYPE_MOBILE and TYPE_WIFI verifications and I have added a try catch block also.

### :boom: How can it be tested?

Configure emulator to poor connection

**UseCase 1**: Open in offline mode the app in a device without a sim card and soft login should work
**UseCase 2**: Open in online mode the app in a device without a sim card and soft login should work

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
