### PR TITLE
Set internationalized name of values loading from data layer

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/SurveyLocalDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/SurveyLocalDataSource.java
@@ -238,13 +238,17 @@ public class SurveyLocalDataSource implements ISurveyRepository {
             QuestionDB questionDB = questionsDBs.get(valueDB.getId_question_fk());
 
             String questionUid = questionDB.getUid();
-            String optionCode;
 
             Value value;
 
             if (valueDB.getId_option_fk() != null) {
-                optionCode = optionDBs.get(valueDB.getId_option_fk()).getCode();
+                OptionDB optionDB = optionDBs.get(valueDB.getId_option_fk());
+                String optionCode = optionDB.getCode();
+
                 value = new Value(valueDB.getValue(), questionUid, optionCode);
+
+                String internationalizedName = optionDB.getInternationalizedName();
+                value.setInternationalizedName(internationalizedName);
             } else {
                 value = new Value(valueDB.getValue(), questionUid);
             }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #2451                    
* **Related pull-requests:** 

###   :gear: branches 
**app**: 
       Origin: maintenance/bug_review_screen_options_name Target: v1.4_connect
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: development   

### :tophat: What is the goal?

Fix a bug where review screen does not show translation name for options but code.

### :memo: How is it being implemented?

When a survey and its values are loaded from the data layer, then I have added the internationalized name to values if the value is an option.

### :boom: How can it be tested?

**UseCase 1**: Create a new survey a review screen should show internationalized name for values from options. 

<img width="332" alt="Captura de pantalla 2020-03-23 a las 8 38 33" src="https://user-images.githubusercontent.com/5593590/77295253-ea27aa00-6ce5-11ea-90a8-f9b7a309a3db.png">


### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
